### PR TITLE
Work/nullability

### DIFF
--- a/DEMO/DEMO.csproj
+++ b/DEMO/DEMO.csproj
@@ -18,10 +18,6 @@
 
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="GeneratedFiles\NonSucking.Framework.Serialization\NonSucking.Framework.Serialization.NoosonGenerator\" />
-	</ItemGroup>
-
 	<Target Name="RemoveSourceGeneratedFiles" BeforeTargets="BeforeBuild">
 		<ItemGroup>
 			<Compile Remove="GeneratedFiles\**" />

--- a/DEMO/NullableTest.cs
+++ b/DEMO/NullableTest.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using NonSucking.Framework.Serialization;
+
+namespace DEMO;
+
+public class SomeData
+{
+    public int Abc { get; set; }
+}
+
+public struct SomeValueData
+{
+    public int Abc { get; set; }
+}
+
+[Nooson]
+public partial class NullableEnabledTest
+{
+    public SomeData NotNull { get; private set; } = new () { Abc = 12};
+    public SomeData? Null { get; private set; } = null;
+    
+    public int? NullableValueType { get; private set; }
+    
+    public SomeValueData? SomeValueData { get; private set; }
+}
+
+#nullable disable
+
+[Nooson]
+public partial class NullableDisabledTest
+{
+    public SomeData NotNull { get; private set; } = new () { Abc = 12};
+    public SomeData? Null { get; private set; } = null;
+    
+    public int? NullableValueType { get; private set; }
+    
+    public SomeValueData? SomeValueData { get; private set; }
+}

--- a/DEMO/RecordTestFile.cs
+++ b/DEMO/RecordTestFile.cs
@@ -20,6 +20,6 @@ public partial record TestRecordCustomContract
     protected virtual Type EqualityContract
     {
         [CompilerGenerated]
-        get => typeof(Abc);
+        get => typeof(TestRecordCustomContract);
     }
 }

--- a/NonSucking.Framework.Extension.Generators.Tests/SerializerGeneratorTest.cs
+++ b/NonSucking.Framework.Extension.Generators.Tests/SerializerGeneratorTest.cs
@@ -23,14 +23,16 @@ namespace NonSucking.Framework.Serialization.Tests
             var singePropTest = @$"{demoPath}SinglePropTest.cs";
             var recordTestFile = @$"{demoPath}RecordTestFile.cs";
             var structTestFile = @$"{demoPath}StructTestFile.cs";
+            var nullableTestFile = @$"{demoPath}NullableTest.cs";
 
             var compilate
             = GeneratorTools.GetGeneratorDiagnostics(new Dictionary<string, string>()
             {
                 //{ recordTestFile, File.ReadAllText(recordTestFile)},
                 //{ structTestFile, File.ReadAllText(structTestFile)},
-                { secondTestFile, File.ReadAllText(secondTestFile)},
-                //{ sutMessage, File.ReadAllText(sutMessage)},
+                { nullableTestFile, File.ReadAllText(nullableTestFile)},
+                // { secondTestFile, File.ReadAllText(secondTestFile)},
+                // { sutMessage, File.ReadAllText(sutMessage)},
                 //{ iUser, File.ReadAllText(iUser)},
                 //{ message, File.ReadAllText(message)},
                 //{ singePropTest, File.ReadAllText(singePropTest)},

--- a/NonSucking.Framework.Serialization/GeneratedSerializerCode.cs
+++ b/NonSucking.Framework.Serialization/GeneratedSerializerCode.cs
@@ -31,13 +31,13 @@ public class GeneratedSerializerCode
     {
         foreach (var declaration in VariableDeclarations)
         {
-            var newDeclaration = variableTransformer == null
+            var newDeclaration = variableTransformer is null
                                     ? declaration.Declaration
                                     : variableTransformer(declaration);
             
             other.VariableDeclarations.Add(new SerializerVariable(newDeclaration, declaration.OriginalMember, declaration.UniqueName, null));
         }
-        return VariableDeclarations.Where(x => x.InitialValue != null).Select(x => x.GetAssignment()).Concat(Statements);
+        return VariableDeclarations.Where(x => x.InitialValue is not null).Select(x => x.GetAssignment()).Concat(Statements);
     }
 
     public void MergeWith(GeneratedSerializerCode other, bool emitVariables = true)
@@ -79,13 +79,13 @@ public class GeneratedSerializerCode
         {
             VariableDeclarations.Add(
                 new SerializerVariable(variableDeclaration, member, memberName,
-                        valueExpression == null ? null : SyntaxFactory.EqualsValueClause(valueExpression)
+                        valueExpression is null ? null : SyntaxFactory.EqualsValueClause(valueExpression)
                     )
                 );
         }
         else
         {
-            VariableDeclarations.Add( new SerializerVariable(variableDeclaration, member, memberName, null));
+            VariableDeclarations.Add(new SerializerVariable(variableDeclaration, member, memberName, null));
             Statements.Add(Statement.Declaration.Assign(memberName, valueExpression));
         }
     }
@@ -137,7 +137,7 @@ public class GeneratedSerializerCode
                     oldVariables.Select(x =>
                                         {
                                             var newInitialValue = tmpThis.InitialValue;
-                                            if (x.Initializer != null && newInitialValue != null)
+                                            if (x.Initializer is not null && newInitialValue is not null)
                                                 throw new NotSupportedException("Cannot assign already assigned variable.");
                                             return
                                                 SyntaxFactory.VariableDeclarator(x.Identifier, x.ArgumentList,

--- a/NonSucking.Framework.Serialization/GeneratedSerializerCode.cs
+++ b/NonSucking.Framework.Serialization/GeneratedSerializerCode.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using VaVare.Statements;
+
+namespace NonSucking.Framework.Serialization;
+
+public class GeneratedSerializerCode
+{
+    public List<SerializerVariable> VariableDeclarations { get; } = new();
+    public List<StatementSyntax> Statements { get; } = new();
+
+    public IEnumerable<StatementSyntax> ToMergedBlock()
+    {
+        foreach (var declaration in VariableDeclarations)
+        {
+            yield return declaration.ToDeclarationAndAssignment();
+        }
+
+        foreach (var statement in Statements)
+        {
+            yield return statement;
+        }
+    }
+
+    public IEnumerable<StatementSyntax> MergeBlocksSeperated(GeneratedSerializerCode other,
+        Func<SerializerVariable, LocalDeclarationStatementSyntax> variableTransformer = null)
+    {
+        foreach (var declaration in VariableDeclarations)
+        {
+            var newDeclaration = variableTransformer == null
+                                    ? declaration.Declaration
+                                    : variableTransformer(declaration);
+            
+            other.VariableDeclarations.Add(new SerializerVariable(newDeclaration, declaration.OriginalMember, declaration.UniqueName, null));
+        }
+        return VariableDeclarations.Where(x => x.InitialValue != null).Select(x => x.GetAssignment()).Concat(Statements);
+    }
+
+    public void MergeWith(GeneratedSerializerCode other, bool emitVariables = true)
+    {
+        if (Statements.Count == 0)
+        {
+            foreach (var d in other.VariableDeclarations)
+                VariableDeclarations.Add(d);
+        }
+        else if (emitVariables)
+        {
+            foreach (var d in other.VariableDeclarations)
+            {
+                VariableDeclarations.Add(new SerializerVariable(d.Declaration, d.OriginalMember, d.UniqueName, null));
+                Statements.Add(d.GetAssignment());
+            }
+        }
+        else
+        {
+            foreach (var d in other.VariableDeclarations)
+            {
+                Statements.Add(d.ToDeclarationAndAssignment());
+            }
+        }
+        foreach (var s in other.Statements)
+            Statements.Add(s);
+    }
+    
+    
+    public void DeclareAndAssign(MemberInfo member, string memberName, ITypeSymbol type, ExpressionSyntax valueExpression)
+    {
+        var typeSyntax = SyntaxFactory.ParseTypeName(type.ToDisplayString()); // TODO better type handling?
+        DeclareAndAssign(member, memberName, typeSyntax, valueExpression);
+    }
+    public void DeclareAndAssign(MemberInfo member, string memberName, TypeSyntax typeSyntax, ExpressionSyntax valueExpression)
+    {
+        var variableDeclaration = Statement.Declaration.Declare(memberName, typeSyntax);
+        if (Statements.Count == 0)
+        {
+            VariableDeclarations.Add(
+                new SerializerVariable(variableDeclaration, member, memberName,
+                        valueExpression == null ? null : SyntaxFactory.EqualsValueClause(valueExpression)
+                    )
+                );
+        }
+        else
+        {
+            VariableDeclarations.Add( new SerializerVariable(variableDeclaration, member, memberName, null));
+            Statements.Add(Statement.Declaration.Assign(memberName, valueExpression));
+        }
+    }
+
+    public readonly struct SerializerVariable
+    {
+        public SerializerVariable(LocalDeclarationStatementSyntax declaration, MemberInfo originalMember, string uniqueName, EqualsValueClauseSyntax initialValue)
+        {
+            Declaration = declaration ?? throw new ArgumentNullException(nameof(declaration));
+            OriginalMember = originalMember;
+            UniqueName = uniqueName;
+            InitialValue = initialValue;
+        }
+
+        public LocalDeclarationStatementSyntax Declaration { get; }
+        
+        public MemberInfo OriginalMember { get; }
+        public string UniqueName { get; }
+        public EqualsValueClauseSyntax InitialValue { get; }
+
+        public EqualsValueClauseSyntax CreateDefaultValue()
+        {
+            return SyntaxFactory.EqualsValueClause(SyntaxFactory.DefaultExpression(Declaration.Declaration.Type));
+        }
+
+        public StatementSyntax GetAssignment()
+        {
+            var variables = Declaration.Declaration.Variables;
+            if (variables.Count > 1)
+            {
+                throw new NotSupportedException("Multiple declaration and assignments in a single statement not supported.");
+            }
+
+            return Statement.Declaration.Assign(variables[0].Identifier.ToFullString(), InitialValue.Value);
+        }
+
+        public LocalDeclarationStatementSyntax ToDeclarationAndAssignment()
+        {
+            var oldDeclaration = Declaration.Declaration;
+            var oldVariables = oldDeclaration.Variables;
+            if (oldVariables.Count > 1)
+            {
+                throw new NotSupportedException("Multiple declaration and assignments in a single statement not supported.");
+            }
+
+            SerializerVariable tmpThis = this;
+            var newVariables =
+                SyntaxFactory.SeparatedList(
+                    oldVariables.Select(x =>
+                                        {
+                                            var newInitialValue = tmpThis.InitialValue;
+                                            if (x.Initializer != null && newInitialValue != null)
+                                                throw new NotSupportedException("Cannot assign already assigned variable.");
+                                            return
+                                                SyntaxFactory.VariableDeclarator(x.Identifier, x.ArgumentList,
+                                                    newInitialValue ?? x.Initializer ?? tmpThis.CreateDefaultValue());
+                                        }));
+            var newDeclaration = SyntaxFactory.VariableDeclaration(oldDeclaration.Type, newVariables);
+            return SyntaxFactory.LocalDeclarationStatement(Declaration.AttributeLists, Declaration.AwaitKeyword,
+                Declaration.UsingKeyword, Declaration.Modifiers, newDeclaration, Declaration.SemicolonToken);
+        }
+    }
+}

--- a/NonSucking.Framework.Serialization/MemberInfo.cs
+++ b/NonSucking.Framework.Serialization/MemberInfo.cs
@@ -2,8 +2,10 @@
 
 namespace NonSucking.Framework.Serialization
 {
-    internal record struct MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
+    public record struct MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
     {
         public string FullName => string.IsNullOrWhiteSpace(Parent) ? Name : $"{Parent}.{Name}";
+
+        public string CreateUniqueName() => Helper.GetRandomNameFor(Name, Parent);
     }
 }

--- a/NonSucking.Framework.Serialization/NoosonGenerator.cs
+++ b/NonSucking.Framework.Serialization/NoosonGenerator.cs
@@ -84,7 +84,7 @@ namespace NonSucking.Framework.Serialization
 
         public static AttributeData GetAttribute(this ISymbol symbol, Template attributeTemplate)
         {
-            if (attributeTemplate == null)
+            if (attributeTemplate is null)
                 throw new ArgumentNullException(nameof(attributeTemplate));
             else if (attributeTemplate.Kind != Templates.TemplateKind.Attribute)
                 throw new ArgumentException(nameof(attributeTemplate) + " is not attribute");
@@ -94,13 +94,13 @@ namespace NonSucking.Framework.Serialization
 
         public static bool TryGetAttribute(this ISymbol symbol, Template attributeTemplate, out AttributeData attributeData)
         {
-            if (attributeTemplate == null)
+            if (attributeTemplate is null)
                 throw new ArgumentNullException(nameof(attributeTemplate));
             else if (attributeTemplate.Kind != Templates.TemplateKind.Attribute)
                 throw new ArgumentException(nameof(attributeTemplate) + " is not attribute");
 
             attributeData = symbol.GetAttributes().FirstOrDefault(x => x.AttributeClass.ToDisplayString() == attributeTemplate.FullName);
-            return attributeData != null;
+            return attributeData is not null;
         }
     }
 

--- a/NonSucking.Framework.Serialization/Serializers/CustomMethodCallSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/CustomMethodCallSerializer.cs
@@ -44,7 +44,7 @@ namespace NonSucking.Framework.Serialization
             var customType = propAttrData.NamedArguments.FirstOrDefault(x => x.Key == "DeserializeImplementationType").Value.Value as ISymbol;
             InvocationExpressionSyntax invocationExpression;
 
-            if (customType != null)
+            if (customType is not null)
             {
                 //Static call
                 invocationExpression
@@ -106,7 +106,7 @@ namespace NonSucking.Framework.Serialization
             }
             StatementSyntax statement;
             var customType = propAttrData.NamedArguments.FirstOrDefault(x => x.Key == "SerializeImplementationType").Value.Value as ISymbol;
-            if (customType != null)
+            if (customType is not null)
             {
                 //Static call
                 statement

--- a/NonSucking.Framework.Serialization/Serializers/CustomMethodCallSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/CustomMethodCallSerializer.cs
@@ -11,12 +11,13 @@ using System.Linq;
 using System.IO;
 using NonSucking.Framework.Serialization.Attributes;
 using System.Linq.Expressions;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace NonSucking.Framework.Serialization
 {
     internal static class CustomMethodCallSerializer
     {
-        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, List<StatementSyntax> statements)
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements)
         {
             var methodName = "Deserialize";
             bool isClassAttribute = false;
@@ -71,9 +72,7 @@ namespace NonSucking.Framework.Serialization
                         .AsExpression();
             }
 
-            statements.Add(Statement
-                .Declaration
-                .DeclareAndAssign($"{Helper.GetRandomNameFor(property.Name, property.Parent)}", invocationExpression));
+            statements.DeclareAndAssign(property, property.CreateUniqueName(), property.TypeSymbol, invocationExpression);
 
             return true;
         }
@@ -81,7 +80,7 @@ namespace NonSucking.Framework.Serialization
 
 
 
-        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName,List<StatementSyntax> statements)
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, GeneratedSerializerCode statements)
         {
             
             var methodName = "Serialize";
@@ -135,7 +134,7 @@ namespace NonSucking.Framework.Serialization
                         .AsStatement();
             }
 
-            statements.Add(statement);
+            statements.Statements.Add(statement);
 
             return true;
 

--- a/NonSucking.Framework.Serialization/Serializers/EnumSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/EnumSerializer.cs
@@ -13,7 +13,7 @@ namespace NonSucking.Framework.Serialization
 {
     internal static class EnumSerializer
     {
-        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName,List<StatementSyntax> statements)
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, GeneratedSerializerCode statements)
         {
 
             var type = property.TypeSymbol;
@@ -27,7 +27,7 @@ namespace NonSucking.Framework.Serialization
             {
                 ValueArgument argument = Helper.GetValueArgumentFrom(property, typeSymbol.EnumUnderlyingType);
 
-                statements.Add(Statement
+                statements.Statements.Add(Statement
                         .Expression
                         .Invoke(writerName, "Write", arguments: new[] { argument })
                         .AsStatement());
@@ -39,7 +39,7 @@ namespace NonSucking.Framework.Serialization
             }
 
         }
-        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName,List<StatementSyntax> statements)
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements)
         {
             
             var type = property.TypeSymbol;
@@ -52,7 +52,6 @@ namespace NonSucking.Framework.Serialization
             if (type is INamedTypeSymbol typeSymbol)
             {
                 SpecialType specialType = typeSymbol.EnumUnderlyingType.SpecialType;
-                string localName = $"{Helper.GetRandomNameFor(property.Name, property.Parent)}";
 
                 ExpressionSyntax invocationExpression
                         = Statement
@@ -68,9 +67,7 @@ namespace NonSucking.Framework.Serialization
                     = SyntaxFactory
                     .CastExpression(typeSyntax, invocationExpression);
 
-                statements.Add(Statement
-                    .Declaration
-                    .DeclareAndAssign(localName, invocationExpression));
+                statements.DeclareAndAssign(property, property.CreateUniqueName(), typeSymbol, invocationExpression);
 
                 return true;
             }

--- a/NonSucking.Framework.Serialization/Serializers/ListSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/ListSerializer.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -22,7 +21,7 @@ namespace NonSucking.Framework.Serialization
 {
     internal static class ListSerializer
     {
-        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, List<StatementSyntax> statements)
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, GeneratedSerializerCode statements)
         {
 
             var type = property.TypeSymbol;
@@ -63,7 +62,6 @@ namespace NonSucking.Framework.Serialization
                         new MemberInfo(genericArgument, genericArgument, itemName),
                         context,
                         writerName);
-            //NoosonGenerator.CreateStatementForSerializing(property, context, writerName);
 
             var memberReference
                 = new MemberReference(
@@ -72,7 +70,7 @@ namespace NonSucking.Framework.Serialization
                     : "Count");
             var countReference = new ReferenceArgument(new VariableReference(Helper.GetMemberAccessString(property), memberReference));
 
-            List<StatementSyntax> preIterationStatements = new();
+            GeneratedSerializerCode preIterationStatements = new();
 
 
 
@@ -80,28 +78,28 @@ namespace NonSucking.Framework.Serialization
             if (count > -1)
                 PublicPropertySerializer.TrySerialize(property, context, writerName, preIterationStatements, count);
 
-            preIterationStatements.Add(
+            preIterationStatements.Statements.Add(
                         Statement
                         .Expression
                         .Invoke(writerName, nameof(BinaryWriter.Write), arguments: new[] { countReference })
                         .AsStatement());
 
-
+            var innerStatements = localStatements.MergeBlocksSeperated(statements);
             var iterationStatement
                 = Statement
                 .Iteration
-                 .ForEach(itemName, typeof(void), Helper.GetMemberAccessString(property), BodyGenerator.Create(localStatements.ToArray()), useVar: true);
+                 .ForEach(itemName, typeof(void), Helper.GetMemberAccessString(property), BodyGenerator.Create(innerStatements.ToArray()), useVar: true);
 
 
-            statements.AddRange(preIterationStatements);
-            statements.Add(iterationStatement);
+            statements.MergeWith(preIterationStatements);
+            statements.Statements.Add(iterationStatement);
 
 
             return true;
         }
 
 
-        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, List<StatementSyntax> statements)
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements)
         {
 
             var type = property.TypeSymbol;
@@ -134,31 +132,23 @@ namespace NonSucking.Framework.Serialization
 
             var randomForThisScope = Helper.GetRandomNameFor("", property.Name);
 
-            List<StatementSyntax> localStatements = new();
             var listVariableName = $"{genericArgument.Name}{randomForThisScope}";
 
-            localStatements.AddRange(NoosonGenerator.CreateStatementForDeserializing(
-                        new MemberInfo(genericArgument, genericArgument, genericArgument.Name),
-                        context,
-                        readerName
-                    ));
+            var itemDeserialization = NoosonGenerator.CreateStatementForDeserializing(
+                new MemberInfo(genericArgument, genericArgument, genericArgument.Name),
+                context,
+                readerName
+            );
 
-            List<StatementSyntax> preIterationStatements = new();
+            GeneratedSerializerCode preIterationStatements = new();
             var count = GetIterationAmount(property.TypeSymbol);
 
             if (count > -1)
                 PublicPropertySerializer.TryDeserialize(property, context, readerName, preIterationStatements, count);
-
-            LocalDeclarationStatementSyntax localDeclarationStatement;
-
-            if (localStatements[0] is BlockSyntax blockSyntax)
-                localDeclarationStatement = GetDeclerationStatement(blockSyntax.Statements);
-            else
-                localDeclarationStatement = GetDeclerationStatement(localStatements);
-
-            listVariableName = localDeclarationStatement.Declaration.Variables.First().Identifier.ToFullString();
-
-            var listName = $"{Helper.GetRandomNameFor(property.Name, property.Parent)}";
+            
+            listVariableName = itemDeserialization.VariableDeclarations.Single().UniqueName;
+            
+            var listName = property.CreateUniqueName();
 
 
             var start = new VariableReference("0");
@@ -170,16 +160,15 @@ namespace NonSucking.Framework.Serialization
                         .Expression
                         .Invoke(readerName, nameof(BinaryReader.ReadInt32))
                         .AsExpression();
-
-            preIterationStatements.Add(
+            preIterationStatements.Statements.Add(
                 Statement
-                .Declaration
-                .DeclareAndAssign(end.Name, invocationExpression));
+                    .Declaration
+                    .DeclareAndAssign(end.Name, invocationExpression));
 
             if (type is IArrayTypeSymbol arrayType)
             {
                 var indexName = Helper.GetRandomNameFor("i", "");
-
+                
                 var nullArrayStatement
                     = SyntaxFactory.ParseStatement($"{genericArgument}[] {listName};");
 
@@ -187,7 +176,7 @@ namespace NonSucking.Framework.Serialization
                     = SyntaxFactory
                     .ExpressionStatement(SyntaxFactory.ParseExpression($"{listName}[{indexName}]={listVariableName}"));
 
-                localStatements.Add(addStatement);
+                itemDeserialization.Statements.Add(addStatement);
 
                 var arrayStatement
                     = Statement
@@ -197,12 +186,12 @@ namespace NonSucking.Framework.Serialization
                 var iterationStatement
                     = Statement
                     .Iteration
-                    .For(start, end, indexName, BodyGenerator.Create(localStatements.ToArray()));
+                    .For(start, end, indexName, BodyGenerator.Create(itemDeserialization.ToMergedBlock().ToArray()));
 
-                statements.Add(nullArrayStatement);
-                statements.AddRange(preIterationStatements);
-                statements.Add(arrayStatement);
-                statements.Add(iterationStatement);
+                statements.DeclareAndAssign(property, listName, SyntaxFactory.ParseTypeName($"{genericArgument}[]"), null);
+                statements.MergeWith(preIterationStatements);
+                statements.Statements.Add(arrayStatement);
+                statements.Statements.Add(iterationStatement);
             }
             else
             {
@@ -213,7 +202,7 @@ namespace NonSucking.Framework.Serialization
                     .Invoke(listName, $"Add", arguments: new[] { new ValueArgument((object)listVariableName) })
                     .AsStatement();
 
-                localStatements.Add(addStatement);
+                itemDeserialization.Statements.Add(addStatement);
 
                 string listInitialize;
                 if (!type.AllInterfaces.Any(x => x.ToDisplayString().StartsWith("System.Collections.ICollection")))
@@ -228,19 +217,15 @@ namespace NonSucking.Framework.Serialization
                     .Invoke($"new {listInitialize}", arguments: new[] { new ValueArgument((object)end.Name) })
                     .AsExpression();
 
-                var listStatement
-                    = Statement
-                    .Declaration
-                    .DeclareAndAssign(listName, ctorInvocationExpression);
 
                 var iterationStatement
                     = Statement
                     .Iteration
-                    .For(start, end, Helper.GetRandomNameFor("i", ""), BodyGenerator.Create(localStatements.ToArray()));
+                    .For(start, end, Helper.GetRandomNameFor("i", ""), BodyGenerator.Create(itemDeserialization.MergeBlocksSeperated(statements).ToArray()));
 
-                statements.AddRange(preIterationStatements);
-                statements.Add(listStatement);
-                statements.Add(iterationStatement);
+                statements.MergeWith(preIterationStatements);
+                statements.DeclareAndAssign(property, listName, SyntaxFactory.ParseTypeName(listInitialize), ctorInvocationExpression);
+                statements.Statements.Add(iterationStatement);
 
             }
 
@@ -289,21 +274,6 @@ namespace NonSucking.Framework.Serialization
             isTypeGeneric = ReferenceEquals(typeForIter, type);
 
             return genericArgument;
-        }
-        private static LocalDeclarationStatementSyntax GetDeclerationStatement(IReadOnlyCollection<StatementSyntax> statements)
-        {
-            LocalDeclarationStatementSyntax localDeclarationStatement;
-
-            if (statements.First() is LocalDeclarationStatementSyntax localDeclarationStatement2)
-            {
-                localDeclarationStatement = localDeclarationStatement2;
-            }
-            else
-            {
-                localDeclarationStatement = null;
-            }
-
-            return localDeclarationStatement;
         }
     }
 }

--- a/NonSucking.Framework.Serialization/Serializers/ListSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/ListSerializer.cs
@@ -247,7 +247,7 @@ namespace NonSucking.Framework.Serialization
         {
             ITypeSymbol genericArgument = null;
             var typeForIter = type;
-            while (genericArgument == null)
+            while (genericArgument is null)
             {
                 if (typeForIter is INamedTypeSymbol nts)
                 {
@@ -255,13 +255,13 @@ namespace NonSucking.Framework.Serialization
                     if (nts.TypeArguments.Length > 0)
                     {
                         genericArgument = nts.TypeArguments[0];
-                        break;
+                        continue;
                     }
                 }
                 else if (typeForIter is IArrayTypeSymbol ats)
                 {
                     genericArgument = ats.ElementType;
-                    break;
+                    continue;
                 }
                 else
                 {

--- a/NonSucking.Framework.Serialization/Serializers/MethodCallSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/MethodCallSerializer.cs
@@ -15,7 +15,7 @@ namespace NonSucking.Framework.Serialization
 {
     internal static class MethodCallSerializer
     {
-        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName,List<StatementSyntax> statements)
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements)
         {
             
             var type = property.TypeSymbol;
@@ -44,9 +44,7 @@ namespace NonSucking.Framework.Serialization
                         .Invoke(type.ToString(), "Deserialize", arguments: new[] { new ValueArgument((object)readerName) })
                         .AsExpression();
 
-                statements.Add(Statement
-                        .Declaration
-                        .DeclareAndAssign($"{Helper.GetRandomNameFor(property.Name, property.Parent)}", invocationExpression));
+                statements.DeclareAndAssign(property, property.CreateUniqueName(), type, invocationExpression);
             }
 
             return isUsable;
@@ -55,7 +53,7 @@ namespace NonSucking.Framework.Serialization
 
 
 
-        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName,List<StatementSyntax> statements)
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, GeneratedSerializerCode statements)
         {
             
             var type = property.TypeSymbol;
@@ -79,7 +77,7 @@ namespace NonSucking.Framework.Serialization
 
             if (isUsable)
             {
-                statements.Add(Statement
+                statements.Statements.Add(Statement
                         .Expression
                         .Invoke(Helper.GetMemberAccessString(property), "Serialize", arguments: new[] { new ValueArgument((object)writerName) })
                         .AsStatement());

--- a/NonSucking.Framework.Serialization/Serializers/NullableSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/NullableSerializer.cs
@@ -1,0 +1,137 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+using static NonSucking.Framework.Serialization.NoosonGenerator;
+
+using VaVare.Statements;
+using NonSucking.Framework.Serialization.Serializers;
+using VaVare.Generators.Common;
+using VaVare.Generators.Common.Arguments.ArgumentTypes;
+
+namespace NonSucking.Framework.Serialization
+{
+    internal static class NullableSerializer
+    {
+        private static bool CanBeNull(MemberInfo property)
+        {
+            if (property.TypeSymbol.Kind == SymbolKind.TypeParameter)
+                return false;
+            return property.TypeSymbol.NullableAnnotation is NullableAnnotation.Annotated or NullableAnnotation.None;
+        }
+
+        private static ITypeSymbol GetNonNullableTypeSymbolAnnotated(INamedTypeSymbol typeSymbol)
+        {
+            if (typeSymbol.NullableAnnotation != NullableAnnotation.Annotated)
+                return typeSymbol;
+            return typeSymbol.ConstructedFrom;
+        }
+        private static ITypeSymbol GetNonNullableTypeSymbol(ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+                return typeSymbol.IsValueType
+                    ? namedTypeSymbol.TypeArguments[0]
+                    : GetNonNullableTypeSymbolAnnotated(namedTypeSymbol);
+            
+
+            return typeSymbol;
+        }
+
+        private static MemberInfo GetNullableValue(MemberInfo property, int baseTypesLevelProperties)
+        {
+            if (property.Symbol is not IPropertySymbol propertySymbol)
+                throw new NotSupportedException();
+            var p
+                = Helper.GetMembersWithBase(property.TypeSymbol, baseTypesLevelProperties)
+                    .First(p 
+                               => p.Name == "Value");
+            return p with { Parent = property.Name };
+        }
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements, int baseTypesLevelProperties = int.MaxValue)
+        {
+            if (!CanBeNull(property))
+                return false;
+            var localIsNotNullName = Helper.GetRandomNameFor("isNotNull", Helper.GetRandomNameFor(property.Name, property.Parent.Replace('.', '_')));
+
+            var nullLiteral = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+            var propertyAccessorName = Helper.GetMemberAccessString(property);
+
+            var isNotNullCheck = SyntaxFactory.IsPatternExpression(
+                SyntaxFactory.IdentifierName(propertyAccessorName),
+                SyntaxFactory.UnaryPattern(SyntaxFactory.ConstantPattern(nullLiteral)));
+
+            var isNotNullDeclaration = Statement.Declaration.DeclareAndAssign(localIsNotNullName, isNotNullCheck);
+            statements.Statements.Add(isNotNullDeclaration);
+
+            var m = property.TypeSymbol.IsValueType
+                ? GetNullableValue(property, baseTypesLevelProperties)
+                : new MemberInfo(GetNonNullableTypeSymbol(property.TypeSymbol), property.Symbol, property.Name,
+                    property.Parent);
+            var innerSerialize = NoosonGenerator.CreateStatementForSerializing(m, context, readerName, true);
+            var b = BodyGenerator.Create(innerSerialize.ToMergedBlock().ToArray());
+
+            var writeNullable = Statement.Expression.Invoke(writerName, "Write",
+                new[] { new VariableArgument(localIsNotNullName) });
+                
+            statements.Statements.Add(writeNullable.AsStatement());
+            statements.Statements.Add(SyntaxFactory.IfStatement(SyntaxFactory.IdentifierName(localIsNotNullName), b));
+            
+
+            return true;
+
+        }
+
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements, int baseTypesLevelProperties = int.MaxValue)
+        {
+            if (!CanBeNull(property))
+                return false;
+
+            var elementType = GetNonNullableTypeSymbol(property.TypeSymbol);
+            var m = new MemberInfo(elementType, property.Symbol, property.Name + (elementType.IsValueType ? "ValueType" : ""), property.Parent);
+
+            var innerDeserialize = CreateStatementForDeserializing(m, context, readerName, true);
+
+            LocalDeclarationStatementSyntax Transform(GeneratedSerializerCode.SerializerVariable variable)
+            {
+                var d = variable.Declaration;
+                if (variable.OriginalMember == m)
+                {
+                    var newDecl = SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName(d.Declaration.Type.ToFullString() + "?"), d.Declaration.Variables);
+                    return SyntaxFactory.LocalDeclarationStatement(d.AttributeLists, d.AwaitKeyword, d.UsingKeyword,
+                        d.Modifiers, newDecl, d.SemicolonToken);
+                }
+                return d;
+            }
+
+            IEnumerable<StatementSyntax> innerStatements = null;
+            if (elementType.IsValueType)
+            {
+                var propName = property.CreateUniqueName();
+                statements.DeclareAndAssign(property, propName, property.TypeSymbol, null);
+                
+                innerStatements = innerDeserialize.ToMergedBlock();
+                innerStatements =
+                    innerStatements.Append(Statement.Declaration.Assign
+                    (propName, SyntaxFactory.IdentifierName(
+                        innerDeserialize.VariableDeclarations.Single(x => x.OriginalMember == m).UniqueName)));
+            }
+            else
+            {
+                innerStatements = innerDeserialize.MergeBlocksSeperated(statements, Transform);
+            }
+            var b = BodyGenerator.Create(innerStatements.ToArray());
+
+            var nullableRead = Statement.Expression
+                .Invoke(readerName, "ReadBoolean");
+
+            statements.Statements.Add(SyntaxFactory.IfStatement(nullableRead.AsExpression(), b));
+            return true;
+        }
+    }
+}

--- a/NonSucking.Framework.Serialization/Serializers/NullableSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/NullableSerializer.cs
@@ -8,12 +8,12 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 
-using static NonSucking.Framework.Serialization.NoosonGenerator;
-
 using VaVare.Statements;
 using NonSucking.Framework.Serialization.Serializers;
 using VaVare.Generators.Common;
 using VaVare.Generators.Common.Arguments.ArgumentTypes;
+
+using static NonSucking.Framework.Serialization.NoosonGenerator;
 
 namespace NonSucking.Framework.Serialization
 {

--- a/NonSucking.Framework.Serialization/Serializers/PublicPropertySerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/PublicPropertySerializer.cs
@@ -7,10 +7,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-using static NonSucking.Framework.Serialization.NoosonGenerator;
-
 using VaVare.Statements;
 using NonSucking.Framework.Serialization.Serializers;
+
+using static NonSucking.Framework.Serialization.NoosonGenerator;
 
 namespace NonSucking.Framework.Serialization
 {

--- a/NonSucking.Framework.Serialization/Serializers/SpecialTypeSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/SpecialTypeSerializer.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text;
-
+using Microsoft.CodeAnalysis.CSharp;
 using VaVare.Generators.Common.Arguments.ArgumentTypes;
 
 using VaVare.Statements;
@@ -12,7 +13,7 @@ namespace NonSucking.Framework.Serialization
 {
     internal static class SpecialTypeSerializer
     {
-        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, List<StatementSyntax> statements)
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName, GeneratedSerializerCode statements)
         {
             var type = property.TypeSymbol;
             switch ((int)type.SpecialType)
@@ -20,7 +21,7 @@ namespace NonSucking.Framework.Serialization
                 case >= 7 and <= 20:
                     ValueArgument argument = Helper.GetValueArgumentFrom(property);
 
-                    statements.Add(Statement
+                    statements.Statements.Add(Statement
                         .Expression
                         .Invoke(writerName, "Write", arguments: new[] { argument })
                         .AsStatement());
@@ -31,14 +32,13 @@ namespace NonSucking.Framework.Serialization
             }
         }
 
-        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, List<StatementSyntax> statements)
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName, GeneratedSerializerCode statements)
         {
             var type = property.TypeSymbol;
 
             switch ((int)type.SpecialType)
             {
                 case >= 7 and <= 20:
-                    string memberName = $"{Helper.GetRandomNameFor(property.Name, property.Parent)}";
 
                     var invocationExpression
                         = Statement
@@ -46,9 +46,10 @@ namespace NonSucking.Framework.Serialization
                         .Invoke(readerName, Helper.GetReadMethodCallFrom(type.SpecialType))
                         .AsExpression();
 
-                    statements.Add(Statement
-                        .Declaration
-                        .DeclareAndAssign(memberName, invocationExpression));
+                    // statements.Add(Statement
+                    //     .Declaration
+                    //     .DeclareAndAssign(memberName, invocationExpression));
+                    statements.DeclareAndAssign(property, property.CreateUniqueName(), type, invocationExpression);
 
                     return true;
                 default:

--- a/NonSucking.Framework.Serialization/Serializers/SpecialTypeSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/SpecialTypeSerializer.cs
@@ -45,10 +45,7 @@ namespace NonSucking.Framework.Serialization
                         .Expression
                         .Invoke(readerName, Helper.GetReadMethodCallFrom(type.SpecialType))
                         .AsExpression();
-
-                    // statements.Add(Statement
-                    //     .Declaration
-                    //     .DeclareAndAssign(memberName, invocationExpression));
+                    
                     statements.DeclareAndAssign(property, property.CreateUniqueName(), type, invocationExpression);
 
                     return true;


### PR DESCRIPTION
Implemented simple nullability serialization
* Only Non nullable annotated reference types are directly serialized, other types are seen as nullable
* Generated serializer code does not contain #nullable trivia to prevent nullability warnings
* Nullable types are serialized by serializing a boolean before serializing the type itself and only append data for the type if it is not null