### PR TITLE
Fixed serialization of properties which inherit from types serialized…

### DIFF
--- a/DEMO/SecondTestFile.cs
+++ b/DEMO/SecondTestFile.cs
@@ -42,6 +42,7 @@ public class ByteLengthList2 : ByteLengthList
     }
 }
 
+// [Nooson] - Not supported to directly generate nooson for class inheriting from ListSerializer types.
 public partial class ByteLengthList : List<byte[]>
 {
     public string NameOfList { get; set; }
@@ -60,7 +61,7 @@ public partial class ByteLengthList : List<byte[]>
     {
 
     }
-    public ByteLengthList(int capacity) : base(capacity)
+    public ByteLengthList([NonSucking.Framework.Serialization.NoosonParameter("count")]int capacity) : base(capacity)
     {
 
     }

--- a/NonSucking.Framework.Serialization/Serializers/PublicPropertySerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/PublicPropertySerializer.cs
@@ -106,7 +106,7 @@ namespace NonSucking.Framework.Serialization
             try
             {
 
-                var ctorSyntax = CtorSerializer.CallCtorAndSetProps((INamedTypeSymbol)property.TypeSymbol, statementList, property, property.CreateUniqueName());
+                var ctorSyntax = CtorSerializer.CallCtorAndSetProps((INamedTypeSymbol)property.TypeSymbol, statements.Statements, property, property.CreateUniqueName());
                 statements.MergeWith(ctorSyntax);
 
             }


### PR DESCRIPTION
… by ListSerializer

* Added mapping of count to capacity in DEMO
* Added info about non support of direct serialization of types inherited from known types by ListSerializer
* Property serializer takes already added local statements from the GeneratedCode parameter to be used as valid already deserialized properties.