### PR TITLE
Fixed duplicate attributes

### DIFF
--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonAttribute.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.IO;
 
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
-    public class NoosonAttribute : Attribute
+    internal class NoosonAttribute : Attribute
     {
     }
 }

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonCustomAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonCustomAttribute.cs
@@ -3,7 +3,7 @@
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Interface | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
-    public class NoosonCustomAttribute : Attribute
+    internal class NoosonCustomAttribute : Attribute
     {
         public Type SerializeImplementationType { get; set; }
         public Type DeserializeImplementationType { get; set; }

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonIgnoreAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonIgnoreAttribute.cs
@@ -3,7 +3,7 @@
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
-    public class NoosonIgnoreAttribute : Attribute
+    internal class NoosonIgnoreAttribute : Attribute
     {
     }
 }

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonIncludeAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonIncludeAttribute.cs
@@ -3,7 +3,7 @@
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
-    public class NoosonIncludeAttribute : Attribute
+    internal class NoosonIncludeAttribute : Attribute
     {
     }
 }

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonOrderAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonOrderAttribute.cs
@@ -3,11 +3,11 @@
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
-    public class NoosonOrderAttribute : Attribute
+    internal class NoosonOrderAttribute : Attribute
     {
-        public int Order { get;  }
+        internal int Order { get; }
 
-        public NoosonOrderAttribute(int order)
+        internal NoosonOrderAttribute(int order)
         {
             Order = order;
         }

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonParameterAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonParameterAttribute.cs
@@ -3,11 +3,11 @@
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false, AllowMultiple = false)]
-    public class NoosonParameterAttribute : Attribute
+    internal class NoosonParameterAttribute : Attribute
     {
-        public string PropertyName { get;  }
+        internal string PropertyName { get; }
 
-        public NoosonParameterAttribute(string propertyName)
+        internal NoosonParameterAttribute(string propertyName)
         {
             PropertyName = propertyName;
         }

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonPreferredCtorAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonPreferredCtorAttribute.cs
@@ -3,7 +3,7 @@
 namespace NonSucking.Framework.Serialization
 {
     [AttributeUsage(AttributeTargets.Constructor, Inherited = false, AllowMultiple = false)]
-    public class NoosonPreferredCtorAttribute : Attribute
+    internal class NoosonPreferredCtorAttribute : Attribute
     {
     }
 }


### PR DESCRIPTION
* when referencing another project that included nooson serializer, by making the attributes internal only, because the attributes wouldn't even work outside of the project, as no source code would be generated

Fixes #30