### PR TITLE
Work/dynamic type support

### DIFF
--- a/DEMO/DynamicTypes.cs
+++ b/DEMO/DynamicTypes.cs
@@ -1,0 +1,37 @@
+using NonSucking.Framework.Serialization;
+
+namespace DEMO;
+
+[Nooson]
+public partial class DynamicTypes
+{
+    [NoosonDynamicType(typeof(D), typeof(C), typeof(B), typeof(A))]
+    [Nooson]
+    public partial class A
+    {
+        
+    }
+
+    [Nooson]
+    public partial class B : A
+    {
+        
+    }
+
+    [Nooson]
+    public partial class C : A
+    {
+        
+    }
+
+    [Nooson]
+    public partial class D : B
+    {
+        
+    }
+    
+    public B SomeProp { get; set; }
+    
+    [NoosonDynamicType(typeof(int), typeof(string))]
+    public object SomeOther { get; set; }
+}

--- a/NonSucking.Framework.Serialization/GeneratedSerializerCode.cs
+++ b/NonSucking.Framework.Serialization/GeneratedSerializerCode.cs
@@ -86,7 +86,8 @@ public class GeneratedSerializerCode
         else
         {
             VariableDeclarations.Add(new SerializerVariable(variableDeclaration, member, memberName, null));
-            Statements.Add(Statement.Declaration.Assign(memberName, valueExpression));
+            if (valueExpression is not null)
+                Statements.Add(Statement.Declaration.Assign(memberName, valueExpression));
         }
     }
 

--- a/NonSucking.Framework.Serialization/NoosonGenerator.cs
+++ b/NonSucking.Framework.Serialization/NoosonGenerator.cs
@@ -305,7 +305,7 @@ namespace NonSucking.Framework.Serialization
                     var methods = new List<BaseMethodDeclarationSyntax>();
                     if (useAdvancedTypes)
                     {
-                        if (generateDefaultReader){}
+                        if (generateDefaultReader)
                             AddSerializeMethods(methods, typeSymbol,
                                 serializeContext with { WriterTypeName = null });
                         if (generateDefaultWriter)
@@ -495,6 +495,7 @@ namespace NonSucking.Framework.Serialization
 
             return GenerateSerialize(modifiers.ToArray(), context, member, generateGeneric, generateConstraint, body, null);
         }
+
         internal static BaseMethodDeclarationSyntax GenerateSerializeMethod(ITypeSymbol typeSymbol, NoosonGeneratorContext context)
         {
             var member = new MemberInfo(typeSymbol, typeSymbol, "that");

--- a/NonSucking.Framework.Serialization/Serializers/DynamicTypeSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/DynamicTypeSerializer.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NonSucking.Framework.Serialization.Attributes;
+using NonSucking.Framework.Serialization.Serializers;
+using VaVare.Generators.Common;
+using VaVare.Generators.Common.Arguments.ArgumentTypes;
+using VaVare.Statements;
+
+namespace NonSucking.Framework.Serialization
+{
+    [StaticSerializer(11)]
+    public class DynamicTypeSerializer
+    {
+        private static bool TryGetAttribute(ITypeSymbol? symbol, out AttributeData? attr)
+        {
+            if (symbol == null)
+            {
+                attr = null;
+                return false;
+            }
+            if (!symbol.TryGetAttribute(AttributeTemplates.DynamicType, out attr))
+            {
+                return TryGetAttribute(symbol.BaseType, out attr);
+            }
+
+            return true;
+        }
+        private static bool IsValidType(MemberInfo property, out IEnumerable<ITypeSymbol>? possibleTypes)
+        {
+            if (!property.Symbol.TryGetAttribute(AttributeTemplates.DynamicType, out var attr))
+            {
+                if (!TryGetAttribute(property.TypeSymbol, out attr))
+                {
+                    possibleTypes = null;
+                    return false;
+                }
+            }
+
+            // TODO: sort
+            possibleTypes = attr!.ConstructorArguments[0].Values.Select(x => x.Value).OfType<ITypeSymbol>();
+            return true;
+        }
+        private static ThrowStatementSyntax ThrowException(string exceptionName)
+        {
+            return SyntaxFactory.ThrowStatement(
+                SyntaxFactory.ObjectCreationExpression(
+                        SyntaxFactory.IdentifierName(exceptionName))
+                    .WithArgumentList(SyntaxFactory.ArgumentList()));
+        }
+        private static ThrowStatementSyntax ThrowNotSupportedException()
+        {
+            return ThrowException("System.NotSupportedException");
+        }
+        private static ThrowStatementSyntax ThrowInvalidCastException()
+        {
+            return ThrowException("System.InvalidCastException");
+        }
+        
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName,
+            GeneratedSerializerCode statements, SerializerMask includedSerializers,
+            int baseTypesLevelProperties = int.MaxValue)
+        {
+            if (!IsValidType(property, out var possibleTypes))
+                return false;
+
+            
+            int typeId = 0;
+
+            var switchSections = new List<SwitchSectionSyntax>();
+
+            var castedName = Helper.GetRandomNameFor("casted", property.CreateUniqueName());
+            
+            foreach (var t in possibleTypes!)
+            {
+                typeId++;
+                
+                if (!IsAssignable(property.TypeSymbol, t))
+                    continue;
+                
+                var newMemberInfo =
+                    property with { Name = castedName, TypeSymbol = t.WithNullableAnnotation(property.TypeSymbol.NullableAnnotation), Parent = ""};
+                
+                var innerSerialize = NoosonGenerator.CreateStatementForSerializing(newMemberInfo, context, writerName, includedSerializers, SerializerMask.DynamicTypeSerializer);
+
+                
+                var invocationExpression
+                    = Statement
+                        .Expression
+                        .Invoke(writerName, "Write", new []{ new ValueArgument(typeId) })
+                        .AsStatement();
+                
+                var b = BodyGenerator.Create(innerSerialize.ToMergedBlock().Append(SyntaxFactory.BreakStatement()).Prepend(invocationExpression).ToArray());
+                switchSections.Add(SyntaxFactory.SwitchSection(
+                    SyntaxFactory.SingletonList<SwitchLabelSyntax>(
+                        SyntaxFactory.CasePatternSwitchLabel(
+                            SyntaxFactory.DeclarationPattern(
+                                SyntaxFactory.ParseTypeName(t.ToDisplayString()),
+                                SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier(castedName)))
+                            , SyntaxFactory.Token(SyntaxKind.ColonToken))),
+                    SyntaxFactory.SingletonList<StatementSyntax>(b)
+                ));
+                
+            }
+            switchSections.Add(SyntaxFactory.SwitchSection(
+                SyntaxFactory.SingletonList<SwitchLabelSyntax>(SyntaxFactory.DefaultSwitchLabel()),
+                SyntaxFactory.SingletonList<StatementSyntax>(ThrowNotSupportedException())));
+
+            statements.Statements.Add(SyntaxFactory.SwitchStatement(SyntaxFactory.IdentifierName(property.FullName))
+                .WithSections(new SyntaxList<SwitchSectionSyntax>(
+                    switchSections
+                )));
+            return true;
+        }
+
+        private static INamedTypeSymbol ResolveType(Compilation compilation, Type? type)
+        {
+            var fullName = type?.FullName;
+            if (fullName is null)
+                throw new ArgumentException();
+            var resolvedType = compilation.GetTypeByMetadataName(fullName);
+            if (resolvedType is null)
+                throw new NotSupportedException($"Unresolvable types are not supported: Could not resolve '{fullName}'");
+
+            return resolvedType;
+        }
+
+        private static bool IsAssignable(ITypeSymbol typeToAssignTo, ITypeSymbol? typeToAssignFrom)
+        {
+            if (typeToAssignFrom is null)
+                return false;
+            if (SymbolEqualityComparer.Default.Equals(typeToAssignFrom, typeToAssignTo))
+                return true;
+            return IsAssignable(typeToAssignTo, typeToAssignFrom.BaseType);
+        }
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName,
+            GeneratedSerializerCode statements, SerializerMask includedSerializers,
+            int baseTypesLevelProperties = int.MaxValue)
+        {
+            if (!IsValidType(property, out var possibleTypes))
+                return false;
+            
+            var invocationExpression
+                = Statement
+                    .Expression
+                    .Invoke(readerName, "ReadInt32")
+                    .AsExpression();
+            var typeIdName = Helper.GetRandomNameFor("typeID", property.CreateUniqueName());
+            statements.Statements.Add(Statement.Declaration.DeclareAndAssign(typeIdName, invocationExpression));
+
+            var propName = property.CreateUniqueName();
+
+            statements.DeclareAndAssign(property, propName, property.TypeSymbol, null);
+            
+            int typeId = 0;
+
+            var switchSections = new List<SwitchSectionSyntax>();
+            
+            foreach (var t in possibleTypes!)
+            {
+                typeId++;
+
+                if (!IsAssignable(property.TypeSymbol, t))
+                {
+                    switchSections.Add(SyntaxFactory.SwitchSection(
+                        SyntaxFactory.SingletonList<SwitchLabelSyntax>(SyntaxFactory.CaseSwitchLabel(
+                            SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(typeId)))),
+                        SyntaxFactory.SingletonList<StatementSyntax>(ThrowInvalidCastException())));
+                    continue;
+                }
+                
+                var newMemberInfo =
+                    property with { TypeSymbol = t.WithNullableAnnotation(property.TypeSymbol.NullableAnnotation) };
+
+                var innerDeserialize = NoosonGenerator.CreateStatementForDeserializing(newMemberInfo, context, readerName, includedSerializers, SerializerMask.DynamicTypeSerializer);
+
+                var resValue = innerDeserialize.VariableDeclarations.Single();
+                
+                innerDeserialize.Statements.Add(Statement.Declaration.Assign(propName, SyntaxFactory.IdentifierName(resValue.UniqueName)));
+                
+                var b = BodyGenerator.Create(innerDeserialize.ToMergedBlock().Append(SyntaxFactory.BreakStatement()).ToArray());
+                switchSections.Add(SyntaxFactory.SwitchSection(
+                    SyntaxFactory.SingletonList<SwitchLabelSyntax>(
+                        SyntaxFactory.CaseSwitchLabel(
+                            SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(typeId)))),
+                        SyntaxFactory.SingletonList<StatementSyntax>(b)
+                    ));
+            }
+
+            switchSections.Add(SyntaxFactory.SwitchSection(
+                SyntaxFactory.SingletonList<SwitchLabelSyntax>(SyntaxFactory.DefaultSwitchLabel()),
+                SyntaxFactory.SingletonList<StatementSyntax>(ThrowNotSupportedException())));
+
+            statements.Statements.Add(SyntaxFactory.SwitchStatement(SyntaxFactory.IdentifierName(typeIdName))
+                .WithSections(new SyntaxList<SwitchSectionSyntax>(
+                    switchSections
+                )));
+            return true;
+        }
+    }
+}

--- a/NonSucking.Framework.Serialization/Serializers/DynamicTypeSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/DynamicTypeSerializer.cs
@@ -53,11 +53,11 @@ namespace NonSucking.Framework.Serialization
         }
         private static ThrowStatementSyntax ThrowNotSupportedException()
         {
-            return ThrowException("System.NotSupportedException");
+            return ThrowException($"{nameof(System)}.{nameof(NotSupportedException)}");
         }
         private static ThrowStatementSyntax ThrowInvalidCastException()
         {
-            return ThrowException("System.InvalidCastException");
+            return ThrowException($"{nameof(System)}.{nameof(InvalidCastException)}");
         }
         
         internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName,

--- a/NonSucking.Framework.Serialization/Serializers/MethodCallSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/MethodCallSerializer.cs
@@ -82,8 +82,6 @@ namespace NonSucking.Framework.Serialization
                     .GetMembers("Serialize")
                     .OfType<IMethodSymbol>();
 
-            bool useStaticCall = true;
-            
             bool hasAttribute = type.TryGetAttribute(AttributeTemplates.GenSerializationAttribute, out var attrData);
 
             bool shouldBeGenerated = hasAttribute;

--- a/NonSucking.Framework.Serialization/Templates/AdditionalSource/BinaryReaderExtensions.cs
+++ b/NonSucking.Framework.Serialization/Templates/AdditionalSource/BinaryReaderExtensions.cs
@@ -10,7 +10,7 @@ namespace NonSucking.Framework.Serialization
             int read = 0;
             do
             {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
                 var res = reader.Read(buffer.Slice(read));
 #else
                 var tmpBuffer = new byte[buffer.Length - read];

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonDynamicTypeAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonDynamicTypeAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NonSucking.Framework.Serialization
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, Inherited = true, AllowMultiple = false)]
+    internal class NoosonDynamicTypeAttribute : Attribute
+    {
+        public NoosonDynamicTypeAttribute(params Type[] possibleTypes)
+        {
+            PossibleTypes = possibleTypes;
+        }
+        public Type[] PossibleTypes { get; }
+    }
+}
+
+

--- a/NonSucking.Framework.Serialization/Templates/NoosonDynamicTypeAttributeTemplate.cs
+++ b/NonSucking.Framework.Serialization/Templates/NoosonDynamicTypeAttributeTemplate.cs
@@ -1,0 +1,11 @@
+﻿using NonSucking.Framework.Serialization.Templates;
+
+namespace NonSucking.Framework.Serialization.Attributes
+{
+    public class NoosonDynamicTypeAttributeTemplate : Template
+    {
+        public override string Namespace { get; } = "NonSucking.Framework.Serialization";
+        public override string Name { get; } = "NoosonDynamicTypeAttribute";
+        public override TemplateKind Kind { get; } = TemplateKind.Attribute;
+    }
+}


### PR DESCRIPTION
Support for dynamic types that are known at compile time and given by the user using the NoosonDynamicType attribute.

The sorting of the types in the attribute is important and needs to be sorted by the inheritance level to the common base type in descending order.
Meaning
```
class A {}
class B : A {}
class C : A {}
class D : B {}
```
results in the following rules:
1. D needs to be before B
2. B and C needs to be in one chunk but can be exchanged
3. B needs to be fore A and C needs to be before A
Possible permutations:
D, C, B, A
D, B, C, A
