### PR TITLE
Added new enumeration modifiable lists and counted scope semaphore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,6 @@ jobs:
         with:
           dotnet-version: '3.1.x' # SDK Version to use.
 
-      # setup dotnet with .NET 5.0
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x' # SDK Version to use.
-
       # setup dotnet with .NET 6.0
       - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v1

--- a/NonSucking.Framework.Extension.Rx/NonSucking.Framework.Extension.Rx.csproj
+++ b/NonSucking.Framework.Extension.Rx/NonSucking.Framework.Extension.Rx.csproj
@@ -2,7 +2,7 @@
 <!-- !#USE_Nuget -->
 <Import Project="$(MSBuildThisFileDirectory)NonSucking.Framework.Extension.Rx.props" Condition="'$(Configuration)'=='Release'" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/NonSucking.Framework.Extension/Collections/CombineEnumerator.cs
+++ b/NonSucking.Framework.Extension/Collections/CombineEnumerator.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonSucking.Framework.Extension.Collections
+{
+    public struct CombineEnumerator<T, TEnumerator1, TEnumerator2> : IEnumerator<T>
+        where TEnumerator1 : IEnumerator<T>
+        where TEnumerator2 : IEnumerator<T>
+    {
+        private readonly TEnumerator1 enum1;
+        private readonly TEnumerator2 enum2;
+
+        public T Current { get; private set; }
+        object IEnumerator.Current => Current;
+
+        public CombineEnumerator(TEnumerator1 enum1, TEnumerator2 enum2)
+        {
+            this.enum1 = enum1;
+            this.enum2 = enum2;
+            Current = default;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            enum1.Dispose();
+            enum2.Dispose();
+        }
+
+        /// <inheritdoc/>
+        public bool MoveNext()
+        {
+            var res = enum1.MoveNext();
+            if (res)
+            {
+                Current = enum1.Current;
+                return res;
+            }
+            res = enum2.MoveNext();
+            if (res)
+                Current = enum2.Current;
+            return res;
+        }
+
+        /// <inheritdoc/>
+        public void Reset()
+        {
+            enum1.Reset();
+            enum2.Reset();
+        }
+    }
+}

--- a/NonSucking.Framework.Extension/Collections/EnumerationmodifiableConcurrentList.cs
+++ b/NonSucking.Framework.Extension/Collections/EnumerationmodifiableConcurrentList.cs
@@ -1,0 +1,201 @@
+﻿using NonSucking.Framework.Extension.Threading;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonSucking.Framework.Extension.Collections
+{
+    /// <summary>
+    /// List that is thread safe and can be modified during enumeration
+    /// </summary>
+    /// <typeparam name="T">Type to hold in the list</typeparam>
+    public class EnumerationModifiableConcurrentList<T> : IList<T>, IReadOnlyCollection<T>
+    {
+        T IList<T>.this[int index]
+        {
+            get
+            {
+                using (scopeSemaphore.EnterCountScope())
+                    return list[index];
+            }
+            set
+            {
+                using (scopeSemaphore.EnterExclusivScope())
+                    list[index] = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public int Count => list.Count;
+        /// <inheritdoc/>
+        public bool IsReadOnly => ((ICollection<T>)list).IsReadOnly;
+
+
+        private readonly List<T> list;
+        private readonly CountedScopeSemaphore scopeSemaphore = new CountedScopeSemaphore();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationModifiableConcurrentList{T}"/> class that is empty and has the default initial capacity.
+        /// </summary>
+        public EnumerationModifiableConcurrentList()
+        {
+            list = new List<T>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationModifiableConcurrentList{T}"/> class that contains elements copied from the specified collection and has sufficient capacity to accommodate the number of elements copied.
+        /// </summary>
+        /// <param name="collection">The collection whose elements are copied to the new list.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="collection" /> is <see langword="null" />.</exception>
+        public EnumerationModifiableConcurrentList(IEnumerable<T> collection)
+        {
+            list = new List<T>(collection);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationModifiableConcurrentList{T}"/> class that is empty and has the specified initial capacity.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the new list can initially store.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="capacity" /> is less than 0.</exception>
+        public EnumerationModifiableConcurrentList(int capacity)
+        {
+            list = new List<T>(capacity);
+        }
+
+        /// <inheritdoc/>
+        public void Add(T item)
+        {
+            using var _ = scopeSemaphore.EnterExclusivScope();
+            list.Add(item);
+        }
+
+        /// <inheritdoc/>
+        public void Clear()
+        {
+            using var _ = scopeSemaphore.EnterExclusivScope();
+            list.Clear();
+        }
+        /// <inheritdoc/>
+        public bool Contains(T item)
+        {
+            using var _ = scopeSemaphore.EnterCountScope();
+            return list.Contains(item);
+        }
+        /// <inheritdoc/>
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            using var _ = scopeSemaphore.EnterExclusivScope();
+            list.CopyTo(array, arrayIndex);
+        }
+        /// <inheritdoc/>
+        public int IndexOf(T item)
+        {
+            using var _ = scopeSemaphore.EnterCountScope();
+            return list.IndexOf(item);
+        }
+        /// <inheritdoc/>
+        public void Insert(int index, T item)
+        {
+            using var _ = scopeSemaphore.EnterExclusivScope();
+            list.Insert(index, item);
+        }
+        /// <inheritdoc/>
+        public bool Remove(T item)
+        {
+            var index = IndexOf(item);
+            if (index == -1)
+                return false;
+
+            RemoveAt(index);
+            return true;
+        }
+        /// <inheritdoc/>
+        public void RemoveAt(int index)
+        {
+            using var _ = scopeSemaphore.EnterExclusivScope();
+            list.RemoveAt(index);
+        }
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Enumerates the elements of a <see cref="EnumerationModifiableConcurrentList{T}"/>.
+        /// </summary>
+        public sealed class Enumerator : IEnumerator<T>
+        {
+            /// <inheritdoc/>
+            public T Current { get; private set; }
+            object IEnumerator.Current => Current;
+
+            private int currentIndex = -1;
+            private readonly EnumerationModifiableConcurrentList<T> parent;
+            private readonly CountedScopeSemaphore scopeSemaphore = new CountedScopeSemaphore();
+
+            internal Enumerator(EnumerationModifiableConcurrentList<T> list)
+            {
+                parent = list;
+            }
+
+            internal void RemoveAt(int index)
+            {
+                using (scopeSemaphore.EnterCountScope())
+                    if (index > currentIndex)
+                        return;
+
+                using (scopeSemaphore.EnterExclusivScope())
+                {
+                    if (index == currentIndex)
+                        Current = default;
+                    currentIndex--;
+                }
+            }
+
+            internal void InsertAt(int index)
+            {
+                using (scopeSemaphore.EnterCountScope())
+                    if (currentIndex < index)
+                        return;
+
+
+                using (scopeSemaphore.EnterExclusivScope())
+                    currentIndex++;
+            }
+
+            /// <inheritdoc/>
+            public void Reset()
+            {
+                currentIndex = -1;
+                Current = default;
+            }
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+            }
+
+            /// <inheritdoc/>
+            public bool MoveNext()
+            {
+                using var _ = scopeSemaphore.EnterExclusivScope();
+
+                currentIndex++;
+                if (currentIndex >= parent.Count)
+                    return false;
+
+                Current = parent.list[currentIndex];
+                return true;
+            }
+
+        }
+
+    }
+}

--- a/NonSucking.Framework.Extension/Collections/EnumerationmodifiableList.cs
+++ b/NonSucking.Framework.Extension/Collections/EnumerationmodifiableList.cs
@@ -1,8 +1,12 @@
-﻿using System;
+﻿
+using NonSucking.Framework.Extension.Pooling;
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace NonSucking.Framework.Extension.Collections
 {
@@ -10,7 +14,7 @@ namespace NonSucking.Framework.Extension.Collections
     /// List that can be modified during enumeration, but is not threadsafe
     /// </summary>
     /// <typeparam name="T">Type to hold in the list</typeparam>
-    public class EnumerationModifiableList<T> : IList<T>, IReadOnlyCollection<T>
+    public class EnumerationmodifiableList<T> : IList<T>, IReadOnlyCollection<T>
     {
         T IList<T>.this[int index]
         {
@@ -31,47 +35,54 @@ namespace NonSucking.Framework.Extension.Collections
 
 
         private readonly List<T> list;
+        private readonly EnumeratorPool pool;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that is empty and has the default initial capacity.
+        /// Initializes a new instance of the <see cref="EnumerationmodifiableList{T}"/> class that is empty and has the default initial capacity.
         /// </summary>
-        public EnumerationModifiableList()
+        public EnumerationmodifiableList()
         {
             list = new List<T>();
+            pool = new(this);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that contains elements copied from the specified collection and has sufficient capacity to accommodate the number of elements copied.
+        /// Initializes a new instance of the <see cref="EnumerationmodifiableList{T}"/> class that contains elements copied from the specified collection and has sufficient capacity to accommodate the number of elements copied.
         /// </summary>
         /// <param name="collection">The collection whose elements are copied to the new list.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="collection" /> is <see langword="null" />.</exception>
-        public EnumerationModifiableList(IEnumerable<T> collection)
+        public EnumerationmodifiableList(IEnumerable<T> collection)
         {
             list = new List<T>(collection);
+            pool = new(this);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that is empty and has the specified initial capacity.
+        /// Initializes a new instance of the <see cref="EnumerationmodifiableList{T}"/> class that is empty and has the specified initial capacity.
         /// </summary>
         /// <param name="capacity">The number of elements that the new list can initially store.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="capacity" /> is less than 0.</exception>
-        public EnumerationModifiableList(int capacity)
+        public EnumerationmodifiableList(int capacity)
         {
             list = new List<T>(capacity);
+            pool = new(this);
         }
 
         /// <inheritdoc/>
         public void Add(T item)
         {
+            var index = list.Count;
             list.Add(item);
+            pool.InsertAt(index);
         }
 
         /// <inheritdoc/>
         public void Clear()
         {
             list.Clear();
+            pool.Clear();
         }
         /// <inheritdoc/>
         public bool Contains(T item)
@@ -92,6 +103,7 @@ namespace NonSucking.Framework.Extension.Collections
         public void Insert(int index, T item)
         {
             list.Insert(index, item);
+            pool.InsertAt(index);
         }
         /// <inheritdoc/>
         public bool Remove(T item)
@@ -107,29 +119,32 @@ namespace NonSucking.Framework.Extension.Collections
         public void RemoveAt(int index)
         {
             list.RemoveAt(index);
+            pool.RemoveAt(index);
         }
 
         /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public Enumerator GetEnumerator() => pool.Get();
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
-        /// Enumerates the elements of a <see cref="EnumerationModifiableList{T}"/>.
+        /// Enumerates the elements of a <see cref="EnumerationmodifiableList{T}"/>.
         /// </summary>
-        public sealed class Enumerator : IEnumerator<T>
+        public sealed class Enumerator : IEnumerator<T>, IPoolElement
         {
             /// <inheritdoc/>
             public T Current { get; private set; }
             object IEnumerator.Current => Current;
 
             private int currentIndex = -1;
-            private readonly EnumerationModifiableList<T> parent;
+            private readonly EnumerationmodifiableList<T> parent;
+            private readonly EnumeratorPool pool;
 
-            internal Enumerator(EnumerationModifiableList<T> list)
+            internal Enumerator(EnumerationmodifiableList<T> list)
             {
                 parent = list;
+                pool = list.pool;
             }
 
             internal void RemoveAt(int index)
@@ -154,7 +169,7 @@ namespace NonSucking.Framework.Extension.Collections
             /// <inheritdoc/>
             public void Dispose()
             {
-                
+                Release();
             }
 
             /// <inheritdoc/>
@@ -175,7 +190,80 @@ namespace NonSucking.Framework.Extension.Collections
                 Current = default;
             }
 
+            /// <inheritdoc/>
+            public void Init(IPool pool)
+            {
+                Reset();
+            }
+
+            /// <inheritdoc/>
+            public void Release()
+            {
+                pool.Push(this);
+            }
         }
 
+        private sealed class EnumeratorPool : IPool<Enumerator>
+        {
+            private readonly Stack<Enumerator> pool = new();
+            private readonly HashSet<Enumerator> gottem = new();
+
+            private readonly EnumerationmodifiableList<T> list;
+
+            public EnumeratorPool(EnumerationmodifiableList<T> list)
+            {
+                this.list = list;
+            }
+
+
+            internal void RemoveAt(int index)
+            {
+                foreach (var item in gottem)
+                    item.RemoveAt(index);
+            }
+
+            internal void InsertAt(int index)
+            {
+                foreach (var item in gottem)
+                    item.InsertAt(index);
+            }
+            internal void Clear()
+            {
+                foreach (var item in gottem)
+                    item.Reset();
+            }
+
+
+            public Enumerator Get()
+            {
+                if (pool.Count > 0)
+                {
+                    Enumerator item;
+                    item = pool.Pop();
+                    item.Reset();
+                    gottem.Add(item);
+                    return item;
+                }
+
+                var e = new Enumerator(list);
+                e.Init(this);
+                gottem.Add(e);
+                return e;
+            }
+
+            public void Push(Enumerator obj)
+            {
+                gottem.Remove(obj);
+                pool.Push(obj);
+            }
+
+            public void Push(IPoolElement obj)
+            {
+                if (obj is Enumerator e)
+                    pool.Push(e);
+                else
+                    throw new ArgumentException(nameof(obj));
+            }
+        }
     }
 }

--- a/NonSucking.Framework.Extension/Collections/EnumerationmodifiableList.cs
+++ b/NonSucking.Framework.Extension/Collections/EnumerationmodifiableList.cs
@@ -14,7 +14,7 @@ namespace NonSucking.Framework.Extension.Collections
     /// List that can be modified during enumeration, but is not threadsafe
     /// </summary>
     /// <typeparam name="T">Type to hold in the list</typeparam>
-    public class EnumerationmodifiableList<T> : IList<T>, IReadOnlyCollection<T>
+    public class EnumerationModifiableList<T> : IList<T>, IReadOnlyCollection<T>
     {
         T IList<T>.this[int index]
         {
@@ -38,33 +38,33 @@ namespace NonSucking.Framework.Extension.Collections
         private readonly EnumeratorPool pool;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EnumerationmodifiableList{T}"/> class that is empty and has the default initial capacity.
+        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that is empty and has the default initial capacity.
         /// </summary>
-        public EnumerationmodifiableList()
+        public EnumerationModifiableList()
         {
             list = new List<T>();
             pool = new(this);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EnumerationmodifiableList{T}"/> class that contains elements copied from the specified collection and has sufficient capacity to accommodate the number of elements copied.
+        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that contains elements copied from the specified collection and has sufficient capacity to accommodate the number of elements copied.
         /// </summary>
         /// <param name="collection">The collection whose elements are copied to the new list.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="collection" /> is <see langword="null" />.</exception>
-        public EnumerationmodifiableList(IEnumerable<T> collection)
+        public EnumerationModifiableList(IEnumerable<T> collection)
         {
             list = new List<T>(collection);
             pool = new(this);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EnumerationmodifiableList{T}"/> class that is empty and has the specified initial capacity.
+        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that is empty and has the specified initial capacity.
         /// </summary>
         /// <param name="capacity">The number of elements that the new list can initially store.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="capacity" /> is less than 0.</exception>
-        public EnumerationmodifiableList(int capacity)
+        public EnumerationModifiableList(int capacity)
         {
             list = new List<T>(capacity);
             pool = new(this);
@@ -129,7 +129,7 @@ namespace NonSucking.Framework.Extension.Collections
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
-        /// Enumerates the elements of a <see cref="EnumerationmodifiableList{T}"/>.
+        /// Enumerates the elements of a <see cref="EnumerationModifiableList{T}"/>.
         /// </summary>
         public sealed class Enumerator : IEnumerator<T>, IPoolElement
         {
@@ -138,10 +138,10 @@ namespace NonSucking.Framework.Extension.Collections
             object IEnumerator.Current => Current;
 
             private int currentIndex = -1;
-            private readonly EnumerationmodifiableList<T> parent;
+            private readonly EnumerationModifiableList<T> parent;
             private readonly EnumeratorPool pool;
 
-            internal Enumerator(EnumerationmodifiableList<T> list)
+            internal Enumerator(EnumerationModifiableList<T> list)
             {
                 parent = list;
                 pool = list.pool;
@@ -208,9 +208,9 @@ namespace NonSucking.Framework.Extension.Collections
             private readonly Stack<Enumerator> pool = new();
             private readonly HashSet<Enumerator> gottem = new();
 
-            private readonly EnumerationmodifiableList<T> list;
+            private readonly EnumerationModifiableList<T> list;
 
-            public EnumeratorPool(EnumerationmodifiableList<T> list)
+            public EnumeratorPool(EnumerationModifiableList<T> list)
             {
                 this.list = list;
             }

--- a/NonSucking.Framework.Extension/Collections/EnumerationmodifiableList.cs
+++ b/NonSucking.Framework.Extension/Collections/EnumerationmodifiableList.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NonSucking.Framework.Extension.Collections
+{
+    /// <summary>
+    /// List that can be modified during enumeration, but is not threadsafe
+    /// </summary>
+    /// <typeparam name="T">Type to hold in the list</typeparam>
+    public class EnumerationModifiableList<T> : IList<T>, IReadOnlyCollection<T>
+    {
+        T IList<T>.this[int index]
+        {
+            get
+            {
+                return list[index];
+            }
+            set
+            {
+                list[index] = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public int Count => list.Count;
+        /// <inheritdoc/>
+        public bool IsReadOnly => ((ICollection<T>)list).IsReadOnly;
+
+
+        private readonly List<T> list;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that is empty and has the default initial capacity.
+        /// </summary>
+        public EnumerationModifiableList()
+        {
+            list = new List<T>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that contains elements copied from the specified collection and has sufficient capacity to accommodate the number of elements copied.
+        /// </summary>
+        /// <param name="collection">The collection whose elements are copied to the new list.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="collection" /> is <see langword="null" />.</exception>
+        public EnumerationModifiableList(IEnumerable<T> collection)
+        {
+            list = new List<T>(collection);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationModifiableList{T}"/> class that is empty and has the specified initial capacity.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the new list can initially store.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="capacity" /> is less than 0.</exception>
+        public EnumerationModifiableList(int capacity)
+        {
+            list = new List<T>(capacity);
+        }
+
+        /// <inheritdoc/>
+        public void Add(T item)
+        {
+            list.Add(item);
+        }
+
+        /// <inheritdoc/>
+        public void Clear()
+        {
+            list.Clear();
+        }
+        /// <inheritdoc/>
+        public bool Contains(T item)
+        {
+            return list.Contains(item);
+        }
+        /// <inheritdoc/>
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            list.CopyTo(array, arrayIndex);
+        }
+        /// <inheritdoc/>
+        public int IndexOf(T item)
+        {
+            return list.IndexOf(item);
+        }
+        /// <inheritdoc/>
+        public void Insert(int index, T item)
+        {
+            list.Insert(index, item);
+        }
+        /// <inheritdoc/>
+        public bool Remove(T item)
+        {
+            var index = IndexOf(item);
+            if (index == -1)
+                return false;
+
+            RemoveAt(index);
+            return true;
+        }
+        /// <inheritdoc/>
+        public void RemoveAt(int index)
+        {
+            list.RemoveAt(index);
+        }
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Enumerates the elements of a <see cref="EnumerationModifiableList{T}"/>.
+        /// </summary>
+        public sealed class Enumerator : IEnumerator<T>
+        {
+            /// <inheritdoc/>
+            public T Current { get; private set; }
+            object IEnumerator.Current => Current;
+
+            private int currentIndex = -1;
+            private readonly EnumerationModifiableList<T> parent;
+
+            internal Enumerator(EnumerationModifiableList<T> list)
+            {
+                parent = list;
+            }
+
+            internal void RemoveAt(int index)
+            {
+                if (index > currentIndex)
+                    return;
+
+                if (index == currentIndex)
+                    Current = default;
+                currentIndex--;
+            }
+
+            internal void InsertAt(int index)
+            {
+                if (currentIndex < index)
+                    return;
+
+
+                currentIndex++;
+            }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                
+            }
+
+            /// <inheritdoc/>
+            public bool MoveNext()
+            {
+                currentIndex++;
+                if (currentIndex >= parent.Count)
+                    return false;
+
+                Current = parent.list[currentIndex];
+                return true;
+            }
+
+            /// <inheritdoc/>
+            public void Reset()
+            {
+                currentIndex = -1;
+                Current = default;
+            }
+
+        }
+
+    }
+}

--- a/NonSucking.Framework.Extension/Collections/IndexableEnumerable.cs
+++ b/NonSucking.Framework.Extension/Collections/IndexableEnumerable.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonSucking.Framework.Extension.Collections
+{
+    public struct IndexableEnumerable<T, TEnumerator>
+        : IEnumerable<(int, T)> where TEnumerator : IEnumerator<T>
+    {
+        private readonly Func<TEnumerator> instantiator;
+
+        public IndexableEnumerable(Func<TEnumerator> instantiator)
+        {
+            this.instantiator = instantiator;
+        }
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        public Enumerator GetEnumerator() => new Enumerator(this);
+        IEnumerator<(int, T)> IEnumerable<(int, T)>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public struct Enumerator : IEnumerator<(int, T)>
+        {
+            private readonly TEnumerator parent;
+            private int index;
+            public Enumerator(IndexableEnumerable<T, TEnumerator> parent)
+            {
+                this.parent = parent.instantiator();
+                Current = default;
+                index = 0;
+            }
+            public (int, T) Current { get; private set; }
+            object IEnumerator.Current => Current;
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                parent.Dispose();
+            }
+            /// <inheritdoc/>
+            public bool MoveNext()
+            {
+                var ret = parent.MoveNext();
+                Current = (index++, parent.Current);
+                return ret;
+            }
+
+            /// <inheritdoc/>
+            public void Reset()
+            {
+                parent.Reset();
+            }
+        }
+    }
+}

--- a/NonSucking.Framework.Extension/NonSucking.Framework.Extension.csproj
+++ b/NonSucking.Framework.Extension/NonSucking.Framework.Extension.csproj
@@ -2,12 +2,10 @@
 	<!-- !#USE_Nuget -->
 	<Import Project="$(MSBuildThisFileDirectory)NonSucking.Framework.Extension.props" Condition="'$(Configuration)'=='Release'" />
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<RepositoryType>git</RepositoryType>
 		<NeutralLanguage>en</NeutralLanguage>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-		<CompilerGeneratedFilesOutputPath>GeneratedFiles</CompilerGeneratedFilesOutputPath>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -20,14 +18,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\NonSucking.Framework.Serialization\NonSucking.Framework.Serialization.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
-	<ItemGroup>
-		<Folder Include="GeneratedFiles" />
-		<Folder Include="GeneratedFiles\**" />
-	</ItemGroup>
-
-	<Target Name="RemoveSourceGeneratedFiles" BeforeTargets="BeforeBuild">
-		<ItemGroup>
-			<Compile Remove="GeneratedFiles\**" />
-		</ItemGroup>
-	</Target>
 </Project>

--- a/NonSucking.Framework.Extension/NonSucking.Framework.Extension.csproj
+++ b/NonSucking.Framework.Extension/NonSucking.Framework.Extension.csproj
@@ -6,6 +6,7 @@
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<RepositoryType>git</RepositoryType>
 		<NeutralLanguage>en</NeutralLanguage>
+		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/NonSucking.Framework.Extension/Pooling/IPool.cs
+++ b/NonSucking.Framework.Extension/Pooling/IPool.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonSucking.Framework.Extension.Pooling
+{
+    public interface IPool
+    {
+        void Push(IPoolElement obj);
+    }
+    public interface IPool<T> : IPool where T : IPoolElement
+    {
+        T Get();
+
+        void Push(T obj);
+    }
+}

--- a/NonSucking.Framework.Extension/Pooling/IPoolElement.cs
+++ b/NonSucking.Framework.Extension/Pooling/IPoolElement.cs
@@ -1,0 +1,8 @@
+﻿namespace NonSucking.Framework.Extension.Pooling
+{
+    public interface IPoolElement
+    {
+        void Init(IPool pool);
+        void Release();
+    }
+}

--- a/NonSucking.Framework.Extension/Pooling/Pool.cs
+++ b/NonSucking.Framework.Extension/Pooling/Pool.cs
@@ -1,0 +1,65 @@
+﻿using NonSucking.Framework.Extension.Threading;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonSucking.Framework.Extension.Pooling
+{
+    public sealed class Pool<T> : IPool<T> where T : IPoolElement, new()
+    {
+        private static readonly Func<T> getInstance;
+
+        static Pool()
+        {
+            var body = Expression.New(typeof(T));
+            getInstance = Expression.Lambda<Func<T>>(body).Compile();
+        }
+
+        private readonly Stack<T> internalStack;
+        private readonly ScopedSemaphore semaphoreExtended;
+
+        public Pool()
+        {
+            internalStack = new Stack<T>();
+            semaphoreExtended = new ScopedSemaphore(1, 1);
+        }
+
+        public T Get()
+        {
+            T obj;
+
+            using (semaphoreExtended.Wait())
+            {
+                if (internalStack.Count > 0)
+                    obj = internalStack.Pop();
+                else
+                    obj = getInstance();
+            }
+
+            obj.Init(this);
+            return obj;
+        }
+
+        public void Push(T obj)
+        {
+            using (semaphoreExtended.Wait())
+                internalStack.Push(obj);
+        }
+
+        public void Push(IPoolElement obj)
+        {
+            if (obj is T t)
+            {
+                Push(t);
+            }
+            else
+            {
+                throw new InvalidCastException("Can not push object from type: " + obj.GetType());
+            }
+        }
+    }
+}

--- a/NonSucking.Framework.Extension/Threading/CountedScopeSemaphore.cs
+++ b/NonSucking.Framework.Extension/Threading/CountedScopeSemaphore.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NonSucking.Framework.Extension.Threading
+{
+    public class CountedScopeSemaphore : IDisposable
+    {
+        private readonly ManualResetEventSlim superLock;
+        private readonly ManualResetEventSlim mainLock;
+
+        private readonly object lockObject;
+        private readonly object countLockObject;
+        private int counter;
+        public CountedScopeSemaphore()
+        {
+            mainLock = new ManualResetEventSlim(true);
+            superLock = new ManualResetEventSlim(true);
+            lockObject = new object();
+            countLockObject = new object();
+        }
+
+        public SuperScope EnterExclusivScope()
+        {
+            lock (lockObject)
+            {
+                mainLock.Wait();
+                superLock.Wait();
+                superLock.Reset();
+            }
+            return new SuperScope(this);
+        }
+
+        public CountScope EnterCountScope()
+        {
+            lock (lockObject)
+            {
+                superLock.Wait();
+                lock (countLockObject)
+                {
+                    counter++;
+                    if (counter > 0)
+                        mainLock.Reset();
+                }
+            }
+
+
+            return new CountScope(this);
+        }
+
+        public void Dispose()
+        {
+            superLock.Dispose();
+            mainLock.Dispose();
+        }
+
+        private void LeaveMainScope()
+        {
+            lock (countLockObject)
+            {
+                counter--;
+                if (counter == 0)
+                    mainLock.Set();
+            }
+        }
+
+        private void LeaveSuperScope()
+        {
+            superLock.Set();
+        }
+
+        public readonly struct CountScope : IDisposable, IEquatable<CountScope>
+        {
+            public static CountScope Empty => new CountScope(null);
+
+            private readonly CountedScopeSemaphore internalSemaphore;
+
+            public CountScope(CountedScopeSemaphore countingSemaphore)
+            {
+                internalSemaphore = countingSemaphore;
+            }
+
+            public void Dispose()
+            {
+                internalSemaphore?.LeaveMainScope();
+            }
+
+            public override bool Equals(object obj)
+                => obj is CountScope scope
+                  && Equals(scope);
+            public bool Equals(CountScope other)
+                => EqualityComparer<CountedScopeSemaphore>.Default.Equals(internalSemaphore, other.internalSemaphore);
+
+            public override int GetHashCode()
+                => 37286538 + EqualityComparer<CountedScopeSemaphore>.Default.GetHashCode(internalSemaphore);
+
+            public static bool operator ==(CountScope left, CountScope right)
+                => left.Equals(right);
+            public static bool operator !=(CountScope left, CountScope right)
+                => !(left == right);
+        }
+
+        public readonly struct SuperScope : IDisposable, IEquatable<SuperScope>
+        {
+            public static SuperScope Empty => new SuperScope(null);
+
+            private readonly CountedScopeSemaphore internalSemaphore;
+
+            public SuperScope(CountedScopeSemaphore semaphore)
+            {
+                internalSemaphore = semaphore;
+            }
+
+            public void Dispose()
+            {
+                internalSemaphore?.LeaveSuperScope();
+            }
+
+            public override bool Equals(object obj) => obj is SuperScope scope && Equals(scope);
+            public bool Equals(SuperScope other)
+                => EqualityComparer<CountedScopeSemaphore>.Default.Equals(internalSemaphore, other.internalSemaphore);
+            public override int GetHashCode()
+                => 37296538 + EqualityComparer<CountedScopeSemaphore>.Default.GetHashCode(internalSemaphore);
+
+            public static bool operator ==(SuperScope left, SuperScope right) => left.Equals(right);
+            public static bool operator !=(SuperScope left, SuperScope right) => !(left == right);
+        }
+    }
+}

--- a/NonSucking.Framework.Serialization.Advanced/NonSucking.Framework.Serialization.Advanced.csproj
+++ b/NonSucking.Framework.Serialization.Advanced/NonSucking.Framework.Serialization.Advanced.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
         <RootNamespace>NonSucking.Framework.Serialization</RootNamespace>
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
* the lists can be used to use a foreach and still add or remove from the list without a problem
* also added a thread safe enumeration modifiable list
* added the counted scope semaphore to distinguish between read and writes for locking
* updated to net 6, because net 5 ist out of support