### PR TITLE
Implemented versioned serializer for nooson

### DIFF
--- a/DEMO/DEMO.csproj
+++ b/DEMO/DEMO.csproj
@@ -3,9 +3,6 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
-		<IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-		<CompilerGeneratedFilesOutputPath>GeneratedFiles</CompilerGeneratedFilesOutputPath>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
@@ -14,21 +11,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Condition="'$(DesignTimeBuild)'!='true'" Include="..\NonSucking.Framework.Serialization\NonSucking.Framework.Serialization.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+		<ProjectReference Include="..\NonSucking.Framework.Serialization\NonSucking.Framework.Serialization.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
 		<ProjectReference Include="..\NonSucking.Framework.Extension\NonSucking.Framework.Extension.csproj" />
 
 	</ItemGroup>
 
-
-	<ItemGroup>
-	  <Folder Include="GeneratedFiles" />
-	  <Folder Include="GeneratedFiles\**" />
-	</ItemGroup>
-
-	<Target Name="RemoveSourceGeneratedFiles" BeforeTargets="BeforeBuild">
-		<ItemGroup>
-			<Compile Remove="GeneratedFiles\**" />
-		</ItemGroup>
-	</Target>
 	
 </Project>

--- a/DEMO/Versioning.cs
+++ b/DEMO/Versioning.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NonSucking.Framework.Serialization;
+
+namespace DEMO;
+
+[Nooson]
+public partial class Versioning
+{
+    [NoosonOrder(int.MinValue)] public int Version { get; set; }
+
+    [NoosonOrder(1)] public string SecondProp { get; set; }
+
+    [NoosonOrder(2)]
+    [NoosonVersioning(nameof(Checker), "", nameof(Version), nameof(SecondProp))]
+    public string NewProp { get; set; }
+
+    [NoosonOrder(3)]
+    [NoosonVersioning(nameof(Checker), "\"asd\"", nameof(Version), nameof(NewProp))]
+    public string NewProp2 { get; set; }
+
+    [NoosonOrder(3)]
+    [NoosonVersioning(nameof(Checker), "123", nameof(Version), nameof(NewProp))]
+    public long NewProp3 { get; set; }
+
+    private static bool Checker(int version, string another)
+    {
+        // defaultValue = default;
+        return false;
+    }
+}

--- a/NonSucking.Framework.Serialization/MemberInfo.cs
+++ b/NonSucking.Framework.Serialization/MemberInfo.cs
@@ -6,7 +6,7 @@ using static NonSucking.Framework.Serialization.GeneratedSerializerCode;
 
 namespace NonSucking.Framework.Serialization
 {
-    public record struct MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
+    public record MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
     {
         public Dictionary<string, string>? ScopeVariableNameMappings { get; set; }
 

--- a/NonSucking.Framework.Serialization/MemberInfo.cs
+++ b/NonSucking.Framework.Serialization/MemberInfo.cs
@@ -1,10 +1,19 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using static NonSucking.Framework.Serialization.GeneratedSerializerCode;
 
 namespace NonSucking.Framework.Serialization
 {
-    public record struct MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
+
+    public record MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
     {
-        public string FullName => (string.IsNullOrWhiteSpace(Parent) || Parent == "this" || Symbol.IsStatic) ? Name : $"{Parent}.{Name}";
+        public Dictionary<string, string>? ScopeVariableNameMappings { get; set; }
+
+        public string FullName =>  (string.IsNullOrWhiteSpace(Parent) || Parent == "this" || Symbol.IsStatic)
+                    ? Name
+                    : $"{Parent}.{Name}";
 
         public string CreateUniqueName() => Helper.GetRandomNameFor(Name, Parent == "this" ? "" : Parent);
     }

--- a/NonSucking.Framework.Serialization/MemberInfo.cs
+++ b/NonSucking.Framework.Serialization/MemberInfo.cs
@@ -6,8 +6,7 @@ using static NonSucking.Framework.Serialization.GeneratedSerializerCode;
 
 namespace NonSucking.Framework.Serialization
 {
-
-    public record MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
+    public record struct MemberInfo(ITypeSymbol TypeSymbol, ISymbol Symbol, string Name, string Parent = "")
     {
         public Dictionary<string, string>? ScopeVariableNameMappings { get; set; }
 

--- a/NonSucking.Framework.Serialization/NoosonGenerator.cs
+++ b/NonSucking.Framework.Serialization/NoosonGenerator.cs
@@ -88,6 +88,7 @@ namespace NonSucking.Framework.Serialization
         internal static readonly NoosonOrderAttributeTemplate Order = new();
         internal static readonly NoosonIncludeAttributeTemplate Include = new();
         internal static readonly NoosonDynamicTypeAttributeTemplate DynamicType = new();
+        internal static readonly NoosonVersioningAttributeTemplate Versioning = new();
 
 
 

--- a/NonSucking.Framework.Serialization/Serializers/KnownSimpleTypeSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/KnownSimpleTypeSerializer.cs
@@ -4,10 +4,13 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Numerics;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 using NonSucking.Framework.Serialization.Serializers;
+
 using VaVare.Generators.Common.Arguments.ArgumentTypes;
 using VaVare.Statements;
 
@@ -41,7 +44,7 @@ internal static class KnownSimpleTypeSerializer
                     SyntaxFactory.Trivia(SyntaxFactory.IfDirectiveTrivia(SyntaxFactory.IdentifierName("!(NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER)"), true, true, true))))
             .WithTrailingTrivia(SyntaxFactory.TriviaList(
                 SyntaxFactory.Trivia(SyntaxFactory.ElseDirectiveTrivia(true, true)))));
-        
+
         statements.Statements.Add(Statement
             .Declaration
             .DeclareAndAssign(bufferName,
@@ -130,7 +133,7 @@ internal static class KnownSimpleTypeSerializer
     {
         return SyntaxFactory.InvocationExpression(
             SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                SyntaxFactory.IdentifierName(propName),SyntaxFactory.IdentifierName(byteMethodName)));
+                SyntaxFactory.IdentifierName(propName), SyntaxFactory.IdentifierName(byteMethodName)));
     }
 
     private static ExpressionSyntax CreateDeserializeFallback(string readerName, ExpressionSyntax size)
@@ -142,7 +145,7 @@ internal static class KnownSimpleTypeSerializer
                 SyntaxFactory.IdentifierName("ReadBytes")),
             SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[] { SyntaxFactory.Argument(size) })));
     }
-    
+
     internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string writerName,
         GeneratedSerializerCode statements, SerializerMask includedSerializers)
     {
@@ -227,7 +230,7 @@ internal static class KnownSimpleTypeSerializer
                             SyntaxFactory.ArgumentList(
                                 SyntaxFactory.SeparatedList<ArgumentSyntax>(
                                     tryWriteParams))))).WithTrailingTrivia(SyntaxFactory.Trivia(SyntaxFactory.EndIfDirectiveTrivia(true))));
-            
+
             statements.Statements.Add(Statement
                 .Expression
                 .Invoke(writerName, "Write", arguments: new[] { new VariableArgument(bufferName) })

--- a/NonSucking.Framework.Serialization/Serializers/PublicPropertySerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/PublicPropertySerializer.cs
@@ -11,7 +11,6 @@ using VaVare.Statements;
 using NonSucking.Framework.Serialization.Serializers;
 
 using static NonSucking.Framework.Serialization.NoosonGenerator;
-using static NonSucking.Framework.Serialization.GeneratedSerializerCode;
 
 namespace NonSucking.Framework.Serialization
 {

--- a/NonSucking.Framework.Serialization/Serializers/VersioningSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/VersioningSerializer.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using VaVare.Statements;
+using NonSucking.Framework.Serialization.Serializers;
+using VaVare.Generators.Common;
+using VaVare.Generators.Common.Arguments.ArgumentTypes;
+using static NonSucking.Framework.Serialization.NoosonGenerator;
+
+namespace NonSucking.Framework.Serialization
+{
+    [StaticSerializer(-1)]
+    internal static class VersioningSerializer
+    {
+        internal static bool TrySerialize(MemberInfo property, NoosonGeneratorContext context, string readerName,
+            GeneratedSerializerCode statements, SerializerMask includedSerializers,
+            int baseTypesLevelProperties = int.MaxValue)
+        {
+            if (!property.Symbol.TryGetAttribute(AttributeTemplates.Versioning, out var versioningAttribute))
+                return false;
+
+            var methodName = versioningAttribute!.ConstructorArguments[0].Value!.ToString();
+
+            var parameters = versioningAttribute.ConstructorArguments[2].Values
+                .Select(x => property.ScopeVariableNameMappings![x.Value!.ToString()]);
+
+            var isNotNullCheck = Statement.Expression.Invoke(
+                    methodName,
+                    arguments: parameters
+                        .Select(x =>
+                            new ValueArgument((object) x))
+                        .ToArray())
+                .AsExpression();
+
+            var m = new MemberInfo(property.TypeSymbol, property.Symbol, property.Name,
+                property.Parent);
+            var innerSerialize = NoosonGenerator.CreateStatementForSerializing(m, context, readerName,
+                includedSerializers, SerializerMask.VersioningSerializer);
+
+            var b = BodyGenerator.Create(innerSerialize.ToMergedBlock().ToArray());
+
+            statements.Statements.Add(SyntaxFactory.IfStatement(isNotNullCheck, b));
+
+
+            return true;
+        }
+        /// <summary>
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="context"></param>
+        /// <param name="readerName"></param>
+        /// <param name="statements"></param>
+        /// <param name="includedSerializers"></param>
+        /// <param name="baseTypesLevelProperties"></param>
+        /// <returns></returns>
+        internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName,
+            GeneratedSerializerCode statements, SerializerMask includedSerializers,
+            int baseTypesLevelProperties = int.MaxValue)
+        {
+            if (!property.Symbol.TryGetAttribute(AttributeTemplates.Versioning, out var versioningAttribute))
+                return false;
+
+
+            var elementType = property.TypeSymbol;
+            var m = new MemberInfo(elementType, property.Symbol, property.Name, property.Parent);
+
+            var innerDeserialize = CreateStatementForDeserializing(m, context, readerName, includedSerializers,
+                SerializerMask.VersioningSerializer);
+            
+
+            LocalDeclarationStatementSyntax Transform(GeneratedSerializerCode.SerializerVariable variable)
+            {
+                var d = variable.Declaration;
+                // if (variable.OriginalMember == m)
+                // {
+                //     var newDecl = SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName(d.Declaration.Type.ToFullString() + "?"), d.Declaration.Variables);
+                //     return SyntaxFactory.LocalDeclarationStatement(d.AttributeLists, d.AwaitKeyword, d.UsingKeyword,
+                //         d.Modifiers, newDecl, d.SemicolonToken);
+                // }
+                return d;
+            }
+
+            IEnumerable<StatementSyntax> innerStatements = innerDeserialize.MergeBlocksSeperated(statements, Transform);
+            
+
+
+            var b = BodyGenerator.Create(innerStatements.ToArray());
+
+            var methodName = versioningAttribute!.ConstructorArguments[0].Value!.ToString();
+
+            var parameters = versioningAttribute.ConstructorArguments[2].Values
+                .Select(x => property.ScopeVariableNameMappings![x.Value!.ToString()]);
+
+            var isNotNullCheck = Statement.Expression.Invoke(
+                    methodName,
+                    arguments: parameters
+                        .Select(x =>
+                            new ValueArgument((object) x))
+                        .ToArray())
+                .AsExpression();
+
+            var ifClause = SyntaxFactory.IfStatement(isNotNullCheck, b);
+            var defaultExpr = versioningAttribute!.ConstructorArguments[1].Value!.ToString();
+
+            if (!string.IsNullOrWhiteSpace(defaultExpr))
+            {
+                var assignmentExpression = SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                    SyntaxFactory.IdentifierName(innerDeserialize.VariableDeclarations.First().UniqueName),
+                    SyntaxFactory.ParseExpression(defaultExpr)).WithLeadingTrivia(SyntaxFactory.LineFeed);
+
+                ifClause = ifClause.WithElse(
+                    
+                    SyntaxFactory.ElseClause(SyntaxFactory.ExpressionStatement(assignmentExpression)));
+            }
+
+            statements.Statements.Add(ifClause);
+            return true;
+        }
+    }
+}

--- a/NonSucking.Framework.Serialization/Serializers/VersioningSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/VersioningSerializer.cs
@@ -49,15 +49,6 @@ namespace NonSucking.Framework.Serialization
 
             return true;
         }
-        /// <summary>
-        /// </summary>
-        /// <param name="property"></param>
-        /// <param name="context"></param>
-        /// <param name="readerName"></param>
-        /// <param name="statements"></param>
-        /// <param name="includedSerializers"></param>
-        /// <param name="baseTypesLevelProperties"></param>
-        /// <returns></returns>
         internal static bool TryDeserialize(MemberInfo property, NoosonGeneratorContext context, string readerName,
             GeneratedSerializerCode statements, SerializerMask includedSerializers,
             int baseTypesLevelProperties = int.MaxValue)
@@ -72,20 +63,7 @@ namespace NonSucking.Framework.Serialization
             var innerDeserialize = CreateStatementForDeserializing(m, context, readerName, includedSerializers,
                 SerializerMask.VersioningSerializer);
             
-
-            LocalDeclarationStatementSyntax Transform(GeneratedSerializerCode.SerializerVariable variable)
-            {
-                var d = variable.Declaration;
-                // if (variable.OriginalMember == m)
-                // {
-                //     var newDecl = SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName(d.Declaration.Type.ToFullString() + "?"), d.Declaration.Variables);
-                //     return SyntaxFactory.LocalDeclarationStatement(d.AttributeLists, d.AwaitKeyword, d.UsingKeyword,
-                //         d.Modifiers, newDecl, d.SemicolonToken);
-                // }
-                return d;
-            }
-
-            IEnumerable<StatementSyntax> innerStatements = innerDeserialize.MergeBlocksSeperated(statements, Transform);
+            IEnumerable<StatementSyntax> innerStatements = innerDeserialize.MergeBlocksSeperated(statements, v => v.Declaration);
             
 
 

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonVersioningAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonVersioningAttribute.cs
@@ -6,7 +6,7 @@ namespace NonSucking.Framework.Serialization
     internal class NoosonVersioningAttribute : Attribute
     {
         /// <summary>
-        /// The method to call for checking the version
+        /// The method to call for checking the version.
         /// </summary>
         public string MethodName { get; set; }
         /// <summary>
@@ -14,10 +14,15 @@ namespace NonSucking.Framework.Serialization
         /// </summary>
         public string DefaultExpression { get; set; }
         /// <summary>
-        /// The parameter names for the <see cref="MethodName"/>, has to be in the correct order
+        /// The parameter names to pass to the <see cref="MethodName"/> method. Properties and fields marked with this attribute need to be ordered after these parameters.
         /// </summary>
         public string[] ParameterNames { get; set; }
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoosonVersioningAttribute"/> class.
+        /// </summary>
+        /// <param name="methodName">The method to call for checking the version.</param>
+        /// <param name="defaultExpression">The c# expression to assign as a default. When empty <see langword="default"/> will be used.</param>
+        /// <param name="parameterNames">The parameter names to pass to the <paramref name="methodName"/> method. Properties and fields marked with this attribute need to be ordered after these parameters.</param>
         public NoosonVersioningAttribute(string methodName, string defaultExpression, params string[] parameterNames)
         {
             MethodName = methodName;

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonVersioningAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonVersioningAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace NonSucking.Framework.Serialization
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = true, AllowMultiple = false)]
+    internal class NoosonVersioningAttribute : Attribute
+    {
+        /// <summary>
+        /// The method to call for checking the version
+        /// </summary>
+        public string MethodName { get; set; }
+        /// <summary>
+        /// The c# expression to assign as a default. When empty <see langword="default"/> will be used.
+        /// </summary>
+        public string DefaultExpression { get; set; }
+        /// <summary>
+        /// The parameter names for the <see cref="MethodName"/>, has to be in the correct order
+        /// </summary>
+        public string[] ParameterNames { get; set; }
+
+        public NoosonVersioningAttribute(string methodName, string defaultExpression, params string[] parameterNames)
+        {
+            MethodName = methodName;
+            DefaultExpression = defaultExpression;
+            ParameterNames = parameterNames;
+
+        }
+    }
+}

--- a/NonSucking.Framework.Serialization/Templates/NoosonVersioningAttributeTemplate.cs
+++ b/NonSucking.Framework.Serialization/Templates/NoosonVersioningAttributeTemplate.cs
@@ -1,0 +1,11 @@
+﻿using NonSucking.Framework.Serialization.Templates;
+
+namespace NonSucking.Framework.Serialization.Attributes
+{
+    public class NoosonVersioningAttributeTemplate : Template
+    {
+        public override string Namespace { get; } = "NonSucking.Framework.Serialization";
+        public override string Name { get; } = "NoosonVersioningAttribute";
+        public override TemplateKind Kind { get; } = TemplateKind.Attribute;
+    }
+}


### PR DESCRIPTION
* so binary serialization can work over multiple versions defined by the developer themselves, with the ability to override the default value on deserialization and pass previously deserialized values into the check method
* added scoped varible names to the deserialization call, so this way one can use those for other purposes

Co-authored-by: jvbsl <13928225+jvbsl@users.noreply.github.com>