### PR TITLE
Added summary for gen type generation

### DIFF
--- a/NonSucking.Framework.Serialization/NoosonGenerator.cs
+++ b/NonSucking.Framework.Serialization/NoosonGenerator.cs
@@ -515,6 +515,9 @@ namespace NonSucking.Framework.Serialization
                 .WithTypeParameters(genType.TypeParameters)
                 .WithTypeConstraintClauses(genType.TypeParameterConstraint);
 
+            if (!string.IsNullOrWhiteSpace(genType.Summary))
+                builder = builder.WithSummary(genType.Summary);
+
             if (generateUsings)
                 builder = builder.WithUsings(usingsArray);
 


### PR DESCRIPTION
* because the property existed, but was never used in the code generation part