### PR TITLE
Added config and fixed bugs

### DIFF
--- a/DEMO.Base/AssemblyInfo.cs
+++ b/DEMO.Base/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using NonSucking.Framework.Serialization;
+[assembly: NoosonConfiguration(
+    GenerateDeserializeExtension = false, 
+    DisableWarnings = true, 
+    GenerateStaticDeserializeWithCtor = true,
+    GenerateDeserializeOnInstance = true,
+    GenerateStaticSerialize = true,
+    GenerateStaticDeserializeIntoInstance =true,
+    NameOfStaticDeserializeWithCtor = "WithCtorBase",
+    NameOfDeserializeOnInstance = "OnInstanceBase",
+    NameOfStaticDeserializeIntoInstance = "IntoInstanceBase",
+    NameOfStaticDeserializeWithOutParams = "ThisHasOutParams2",
+    NameOfSerialize = "OwnSerialize",
+    NameOfStaticSerialize = "StaticSerialize")]

--- a/DEMO.Base/BaseClassWithNooson.cs
+++ b/DEMO.Base/BaseClassWithNooson.cs
@@ -1,0 +1,99 @@
+﻿using NonSucking.Framework.Serialization;
+
+namespace DEMO.Base;
+
+[Nooson]
+public partial class BaseClassWithNooson : BaseClassWithoutNoosonButMethods
+{
+}
+
+public class BaseClassWithoutNoosonButMethods : BaseBaseClassWithoutNoosonButMethods
+{
+    public int TestProp1 { get; set; }
+
+    ///<summary>
+    ///Serializes the given <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods"/> instance.
+    ///</summary>
+    ///<param name = "that">The instance to serialize.</param>
+    ///<param name = "writer">The <see cref="System.IO.BinaryWriter"/> to serialize to.</param>
+    public static void StaticSerialize(DEMO.Base.BaseClassWithoutNoosonButMethods that, System.IO.BinaryWriter writer)
+    {
+        that.OwnSerialize(writer);
+    }
+
+    ///<summary>
+    ///Serializes this instance.
+    ///</summary>
+    ///<param name = "writer">The <see cref="System.IO.BinaryWriter"/> to serialize to.</param>
+    public virtual void OwnSerialize(System.IO.BinaryWriter writer)
+    {
+        writer.Write(TestProp1);
+    }
+
+    ///<summary>
+    ///Deserializes the properties of a <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods"/> type.
+    ///</summary>
+    ///<param name = "reader">The <see cref="System.IO.BinaryReader"/> to deserialize from.</param>
+    ///<param name = "TestProp1_️ret_️k">The deserialized instance of the property <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods.TestProp1"/>.</param>
+    ///<param name = "TestProp1_️ret_️l">The deserialized instance of the property <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods.TestProp1"/>.</param>
+    public static void ThisHasOutParams(System.IO.BinaryReader reader, out int Test2, out int TestProp1_️ret_️k)
+    {
+        TestProp1_️ret_️k = reader.ReadInt32();
+        Test2 = reader.ReadInt32();
+    }
+
+    ///<summary>
+    ///Deserializes a <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods"/> instance.
+    ///</summary>
+    ///<param name = "reader">The <see cref="System.IO.BinaryReader"/> to deserialize from.</param>
+    ///<returns>The deserialized instance.</returns>
+    public static DEMO.Base.BaseClassWithoutNoosonButMethods WithCtorBase(System.IO.BinaryReader reader)
+    {
+        DEMO.Base.BaseClassWithoutNoosonButMethods ret_️_️o = default(DEMO.Base.BaseClassWithoutNoosonButMethods)!;
+        DEMO.Base.BaseClassWithoutNoosonButMethods.ThisHasOutParams(reader, out var TestProp1_️ret_️m, out _);
+        ret_️_️o = new DEMO.Base.BaseClassWithoutNoosonButMethods()
+        {
+            TestProp1 = TestProp1_️ret_️m
+        };
+        return ret_️_️o;
+    }
+
+    ///<summary>
+    ///Deserializes into <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods"/> instance.
+    ///</summary>
+    ///<param name = "that">The instance to deserialize into.</param>
+    ///<param name = "reader">The <see cref="System.IO.BinaryReader"/> to deserialize from.</param>
+    public static void IntoInstanceBase(DEMO.Base.BaseClassWithoutNoosonButMethods that, System.IO.BinaryReader reader)
+    {
+        DEMO.Base.BaseClassWithoutNoosonButMethods.ThisHasOutParams(reader, out var TestProp1_️ret_️s, out _);
+        that.TestProp1 = TestProp1_️ret_️s;
+    }
+
+    ///<summary>
+    ///Deserializes into <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods"/> instance.
+    ///</summary>
+    ///<param name = "reader">The <see cref="System.IO.BinaryReader"/> to deserialize from.</param>
+    public virtual void OnInstanceBase(System.IO.BinaryReader reader)
+    {
+        DEMO.Base.BaseClassWithoutNoosonButMethods.IntoInstanceBase(this, reader);
+    }
+
+}
+
+
+public class BaseBaseClassWithoutNoosonButMethods
+{
+    ///<summary>
+    ///Deserializes the properties of a <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods"/> type.
+    ///</summary>
+    ///<param name = "reader">The <see cref="System.IO.BinaryReader"/> to deserialize from.</param>
+    ///<param name = "TestProp1_️ret_️k">The deserialized instance of the property <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods.TestProp1"/>.</param>
+    ///<param name = "TestProp1_️ret_️l">The deserialized instance of the property <see cref="DEMO.Base.BaseClassWithoutNoosonButMethods.TestProp1"/>.</param>
+    public static void ThisHasOutParams(System.IO.BinaryReader reader, out string p, out int TestProp1_️ret_️k)
+    {
+        TestProp1_️ret_️k = reader.ReadInt32();
+        p = "";
+    }
+
+
+}

--- a/DEMO.Base/BaseClassWithoutNooson.cs
+++ b/DEMO.Base/BaseClassWithoutNooson.cs
@@ -1,0 +1,5 @@
+﻿namespace DEMO.Base;
+public class BaseClassWithoutNooson
+{
+    public string None { get; set; }
+}

--- a/DEMO.Base/DEMO.Base.csproj
+++ b/DEMO.Base/DEMO.Base.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+
+	<ItemGroup>
+		<ProjectReference Include="..\NonSucking.Framework.Serialization\NonSucking.Framework.Serialization.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+
+	</ItemGroup>
+</Project>

--- a/DEMO/AssemblyInfo.cs
+++ b/DEMO/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using NonSucking.Framework.Serialization;
+
+[assembly: NoosonConfiguration(
+    GenerateDeserializeExtension = false, 
+    DisableWarnings = false, 
+    GenerateStaticDeserializeWithCtor = true,
+    GenerateDeserializeOnInstance = true,
+    GenerateStaticSerialize = true,
+    GenerateStaticDeserializeIntoInstance =true,
+    NameOfStaticDeserializeWithCtor = "WithCtor",
+    NameOfDeserializeOnInstance = "OnInstance",
+    NameOfStaticDeserializeIntoInstance = "IntoInstance",
+    NameOfStaticDeserializeWithOutParams = "ThisHasOutParams")]

--- a/DEMO/DEMO.csproj
+++ b/DEMO/DEMO.csproj
@@ -5,7 +5,6 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
-
 	<ItemGroup>
 	  <None Include="..\.editorconfig" Link=".editorconfig" />
 	</ItemGroup>
@@ -15,6 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\DEMO.Base\DEMO.Base.csproj" />
 		<ProjectReference Include="..\NonSucking.Framework.Serialization\NonSucking.Framework.Serialization.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
 		<ProjectReference Include="..\NonSucking.Framework.Extension\NonSucking.Framework.Extension.csproj" />
 

--- a/DEMO/DemoBaseImplementation.cs
+++ b/DEMO/DemoBaseImplementation.cs
@@ -1,0 +1,33 @@
+﻿using DEMO.Base;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NonSucking.Framework.Serialization;
+
+namespace DEMO;
+
+[Nooson]
+internal partial class DemoBaseImplementation : BaseClassWithNooson
+{
+    public int Type { get; set; }
+}
+
+[Nooson]
+internal partial class SecondDemoBaseImplementation : DemoBaseImplementation
+{
+    public int Type2 { get; set; }
+}
+
+[Nooson]
+internal partial class StringDemoBaseImplementation : BaseClassWithNooson
+{
+    public string Test { get; set; }
+}
+
+[Nooson]
+internal partial class NothingAddedDemoBaseImplementation : BaseClassWithNooson
+{
+}

--- a/DEMO/DynamicTypes.cs
+++ b/DEMO/DynamicTypes.cs
@@ -26,7 +26,7 @@ public partial class DynamicTypes
     [Nooson]
     public partial class D : B
     {
-
+        public int Aaa { get; set; }
     }
 
     public A SomeProp { get; set; }

--- a/DEMO/InheritanceTest.cs
+++ b/DEMO/InheritanceTest.cs
@@ -8,8 +8,18 @@ public partial class InheritanceBaseClass
     public int SomeValue { get; set; }
 }
 
-[Nooson]
-public partial class InheritanceTest : InheritanceBaseClass
-{
-    public string OtherValue { get; set; }
-}
+//[Nooson]
+//public partial class InheritanceTest : InheritanceBaseClass
+//{
+//    public string OtherValue { get; set; }
+//}
+//[Nooson]
+//public partial class InheritanceTest2 : InheritanceTest
+//{
+//    public string OtherValue2 { get; set; }
+//}
+//[Nooson]
+//public partial class InheritanceTest3 : InheritanceTest2
+//{
+//    public string OtherValue3 { get; set; }
+//}

--- a/DEMO/InheritanceTest.cs
+++ b/DEMO/InheritanceTest.cs
@@ -8,18 +8,18 @@ public partial class InheritanceBaseClass
     public int SomeValue { get; set; }
 }
 
-//[Nooson]
-//public partial class InheritanceTest : InheritanceBaseClass
-//{
-//    public string OtherValue { get; set; }
-//}
-//[Nooson]
-//public partial class InheritanceTest2 : InheritanceTest
-//{
-//    public string OtherValue2 { get; set; }
-//}
-//[Nooson]
-//public partial class InheritanceTest3 : InheritanceTest2
-//{
-//    public string OtherValue3 { get; set; }
-//}
+[Nooson]
+public partial class InheritanceTest : InheritanceBaseClass
+{
+    public string OtherValue { get; set; }
+}
+[Nooson]
+public partial class InheritanceTest2 : InheritanceTest
+{
+    public string OtherValue2 { get; set; }
+}
+[Nooson]
+public partial class InheritanceTest3 : InheritanceTest2
+{
+    public string OtherValue3 { get; set; }
+}

--- a/DEMO/NestedTypes.cs
+++ b/DEMO/NestedTypes.cs
@@ -1,5 +1,7 @@
 using NonSucking.Framework.Serialization;
 
+using System.Composition;
+
 namespace DEMO;
 
 public partial class NestedTypes

--- a/DEMO/Program.cs
+++ b/DEMO/Program.cs
@@ -76,7 +76,7 @@ namespace DEMO
             using (var ms = new FileStream("sut.save", FileMode.Open))
             {
                 using var br = new BinaryReader(ms);
-                var sutMessageDes = SUTMessage.Deserialize(br);
+                var sutMessageDes = SUTMessage.WithCtor(br);
 
                 if (sutMessageDes == sutMessage)
                 {

--- a/DEMO/SUTMessage.cs
+++ b/DEMO/SUTMessage.cs
@@ -161,6 +161,7 @@ namespace DEMO
             && ReadOnlyDicSetable.SequenceEqual(other.ReadOnlyDicSetable)
             && Right == other.Right
             && EqualityComparer<ComplainBase>.Default.Equals(Complain, other.Complain)
+            && EqualityComparer<ComplainBase>.Default.Equals(ComplainComplain, other.ComplainComplain)
             && EqualityComparer<User>.Default.Equals(AssignedUser, other.AssignedUser)
             && Position.Equals(other.Position)
             && EqualityComparer<IUser>.Default.Equals(ContactUser, other.ContactUser)

--- a/DEMO/SinglePropTest.cs
+++ b/DEMO/SinglePropTest.cs
@@ -19,6 +19,26 @@ namespace DEMO
         public Point Position { get; set; }
         //public IEnumerable HelloWorld { get; set; }
 
+    }
 
+    internal partial class SinglePropNonNoosonTest : SinglePropFirst
+    {
+        //[NoosonOrder(2)]
+        public bool IsEmpty { get; set; }
+        [NoosonOrder(1)]
+        public Point Position2 { get; set; }
+        [NoosonOrder(0)]
+        public Point Position { get; set; }
+        //public IEnumerable HelloWorld { get; set; }
+
+
+    }
+
+    [Nooson]
+    public partial class MultipleSinglePropTest
+    {
+        internal SinglePropNonNoosonTest Jonny { get; set; }
+        internal SinglePropNonNoosonTest Second { get; set; }
+        internal SinglePropNonNoosonTest Third { get; set; }
     }
 }

--- a/NonSucking.Framework.Serialization/AttributeTemplates.cs
+++ b/NonSucking.Framework.Serialization/AttributeTemplates.cs
@@ -10,6 +10,8 @@ namespace NonSucking.Framework.Serialization
 {
     public static class AttributeTemplates
     {
+        internal static readonly NoosonConfigurationAttributeTemplate NoosonConfiguration = new();
+
         internal static readonly NoosonIgnoreAttributeTemplate Ignore = new();
         internal static readonly NoosonPreferredCtorAttributeTemplate PreferredCtor = new();
         internal static readonly NoosonParameterAttributeTemplate Parameter = new();

--- a/NonSucking.Framework.Serialization/Consts.cs
+++ b/NonSucking.Framework.Serialization/Consts.cs
@@ -12,4 +12,5 @@ internal static class Consts
     internal const string DeserializeSelf = nameof(DeserializeSelf);
     internal const string InstanceParameterName = "that";
     internal const string ThisName = "this";
+    internal const string LocalVariableSuffix = "_️"; //VARIATION SELECTOR-16 _, looks better and provides better uniqueness
 }

--- a/NonSucking.Framework.Serialization/GeneratedMethod.cs
+++ b/NonSucking.Framework.Serialization/GeneratedMethod.cs
@@ -7,11 +7,12 @@ using VaVare.Models;
 
 namespace NonSucking.Framework.Serialization
 {
-    public record GeneratedMethod(GeneratedMethodParameter? ReturnType, string Name, List<GeneratedMethodParameter> Parameters, List<Modifiers> Modifier, TypeParameter[] TypeParameters, TypeParameterConstraintClause[] TypeParameterConstraints, GeneratedSerializerCode Body, string? Summary)
+    public record GeneratedMethod(GeneratedMethodParameter? ReturnType, string Name, string OverridenName, List<GeneratedMethodParameter> Parameters, List<Modifiers> Modifier, TypeParameter[] TypeParameters, TypeParameterConstraintClause[] TypeParameterConstraints, GeneratedSerializerCode Body, string? Summary)
     {
         public bool IsVirtual => Modifier.Any(x => x == Modifiers.Virtual);
         public bool IsAbstract => Modifier.Any(x => x == Modifiers.Abstract);
         public bool IsStatic => Modifier.Any(x => x == Modifiers.Static);
+        public bool IsOverride => Modifier.Any(x => x == Modifiers.Override);
         public virtual bool Equals(GeneratedMethod? other)
         {
             if (other is null)
@@ -19,6 +20,7 @@ namespace NonSucking.Framework.Serialization
             if (ReferenceEquals(this, other))
                 return true;
             return Name == other.Name
+                && OverridenName == other.OverridenName
                 && Summary == other.Summary
                 && (Parameters.Equals(other.Parameters)
                     || Parameters.SequenceEqual(other.Parameters))

--- a/NonSucking.Framework.Serialization/GlobalContext.cs
+++ b/NonSucking.Framework.Serialization/GlobalContext.cs
@@ -1,29 +1,48 @@
 ﻿using Microsoft.CodeAnalysis;
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace NonSucking.Framework.Serialization
 {
 
-    public record GlobalContext(Dictionary<string, GeneratedFile> GeneratedTypes)
+    public record GlobalContext(Dictionary<string, GeneratedFile> GeneratedTypes, Compilation Compilation, NoosonConfig Config)
     {
+        Dictionary<AssemblyIdentity, NoosonConfig> ThirdPartyConfigs { get; set; } = new();
         public GeneratedFile? Resolve(ITypeSymbol? symbol)
         {
             return symbol is not null && TryResolve(symbol, out var type) ? type : null;
         }
         public bool TryResolve(ITypeSymbol symbol, out GeneratedFile generatedType)
         {
-            return GeneratedTypes.TryGetValue(symbol.ToDisplayString(), out generatedType);
+            return GeneratedTypes.TryGetValue(symbol.OriginalDefinition.ToDisplayString(), out generatedType);
         }
         public void Add(ITypeSymbol symbol, GeneratedFile generatedType)
         {
-            GeneratedTypes.Add(symbol.ToDisplayString(), generatedType);
+            GeneratedTypes.Add(symbol.OriginalDefinition.ToDisplayString(), generatedType);
+        }
+
+        public NoosonConfig GetConfigForSymbol(ISymbol symbol)
+        {
+            if(symbol.ContainingAssembly is null)
+            {
+                return new NoosonConfig(true);
+            }
+
+            if (!ThirdPartyConfigs.TryGetValue(symbol.ContainingAssembly.Identity, out var config))
+            {
+                var attribute = symbol.ContainingAssembly.GetAttribute(AttributeTemplates.NoosonConfiguration);
+                return ThirdPartyConfigs[symbol.ContainingAssembly.Identity] = new NoosonConfig(true).ReloadFrom(attribute);
+            }
+            return config;
         }
         /// <summary>
         /// Cleans everything, so no caches are left over
         /// </summary>
         public void Clean()
         {
+            ThirdPartyConfigs.Clear();
             GeneratedTypes.Clear();
         }
     }

--- a/NonSucking.Framework.Serialization/Helper.cs
+++ b/NonSucking.Framework.Serialization/Helper.cs
@@ -391,7 +391,7 @@ namespace NonSucking.Framework.Serialization
                 index++;
             }
 
-            return true;
+            return second.Count == index;
         }
     }
 }

--- a/NonSucking.Framework.Serialization/NonSucking.Framework.Serialization.csproj
+++ b/NonSucking.Framework.Serialization/NonSucking.Framework.Serialization.csproj
@@ -3,7 +3,7 @@
 	<Import Project="$(MSBuildThisFileDirectory)NonSucking.Framework.Serialization.props" Condition="'$(Configuration)'=='Release'" />
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<!-- Special properties for analyzer packages. -->
 		<IncludeBuildOutput>false</IncludeBuildOutput>

--- a/NonSucking.Framework.Serialization/NoosonConfig.cs
+++ b/NonSucking.Framework.Serialization/NoosonConfig.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.CodeAnalysis;
+
+using System.Linq;
+
+namespace NonSucking.Framework.Serialization
+{
+    public record struct NoosonConfig(
+        bool GenerateDeserializeExtension = true,
+        bool DisableWarnings = false,
+        string NameOfStaticDeserializeWithOutParams = Consts.Deserialize,
+        
+        bool GenerateStaticDeserializeWithCtor = true,
+        string NameOfStaticDeserializeWithCtor = Consts.Deserialize,
+        
+        bool GenerateStaticDeserializeIntoInstance = true,
+        string NameOfStaticDeserializeIntoInstance = Consts.Deserialize,
+
+        bool GenerateDeserializeOnInstance = true,
+        string NameOfDeserializeOnInstance = Consts.DeserializeSelf,
+
+        bool GenerateStaticSerialize = true,
+        string NameOfStaticSerialize = Consts.Serialize,
+        string NameOfSerialize = Consts.Serialize,
+
+        bool EnableNullability = false)
+    {
+        public int ShouldContainMethodsCount { get; private set; }
+
+        public NoosonConfig ReloadFrom(AttributeData? data)
+        {
+            if (data is null)
+                return this;
+            var nm = data.NamedArguments;
+            var config = this;
+            if (nm.FirstOrDefault(x => x.Key == nameof(EnableNullability)).Value.Value is bool disableNullable)
+                config = config with { EnableNullability = disableNullable };
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(DisableWarnings)).Value.Value is bool disableWarnings)
+                config = config with { DisableWarnings = disableWarnings };
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(NameOfStaticDeserializeWithOutParams)).Value.Value is string nameOfStaticDeserializeWithOutParams)
+                config = config with { NameOfStaticDeserializeWithOutParams = nameOfStaticDeserializeWithOutParams };
+            
+            if (nm.FirstOrDefault(x => x.Key == nameof(GenerateDeserializeExtension)).Value.Value is bool generateExtensions)
+                config = config with { GenerateDeserializeExtension = generateExtensions };
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(GenerateStaticDeserializeWithCtor)).Value.Value is bool generateStaticDeserializeWithCtor)
+                config = config with { GenerateStaticDeserializeWithCtor = generateStaticDeserializeWithCtor };
+            if (nm.FirstOrDefault(x => x.Key == nameof(NameOfStaticDeserializeWithCtor)).Value.Value is string nameOfStaticDeserializeWithCtor)
+                config = config with { NameOfStaticDeserializeWithCtor = nameOfStaticDeserializeWithCtor };
+            
+            if (nm.FirstOrDefault(x => x.Key == nameof(GenerateDeserializeOnInstance)).Value.Value is bool generateDeserializeOnInstance)
+                config = config with { GenerateDeserializeOnInstance = generateDeserializeOnInstance };
+            if (nm.FirstOrDefault(x => x.Key == nameof(NameOfDeserializeOnInstance)).Value.Value is string nameOfDeserializeOnInstance)
+                config = config with { NameOfDeserializeOnInstance = nameOfDeserializeOnInstance };            
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(GenerateStaticDeserializeIntoInstance)).Value.Value is bool generateStaticDeserializeIntoInstance)
+                config = config with { GenerateStaticDeserializeIntoInstance = generateStaticDeserializeIntoInstance };
+            if (nm.FirstOrDefault(x => x.Key == nameof(NameOfStaticDeserializeIntoInstance)).Value.Value is string nameOfStaticDeserializeIntoInstance)
+                config = config with { NameOfStaticDeserializeIntoInstance = nameOfStaticDeserializeIntoInstance };
+
+            if(!config.GenerateStaticDeserializeIntoInstance && config.GenerateDeserializeOnInstance)
+                config = config with { GenerateStaticDeserializeIntoInstance =  config.GenerateDeserializeOnInstance };
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(GenerateStaticSerialize)).Value.Value is bool generateStaticSerialize)
+                config = config with { GenerateStaticSerialize = generateStaticSerialize };
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(NameOfStaticSerialize)).Value.Value is string nameOfStaticSerialize)
+                config = config with { NameOfStaticSerialize = nameOfStaticSerialize };
+
+            if (nm.FirstOrDefault(x => x.Key == nameof(NameOfSerialize)).Value.Value is string nameOfSerialize)
+                config = config with { NameOfSerialize = nameOfSerialize };
+
+            config.ShouldContainMethodsCount = 
+                AddB(config.GenerateDeserializeExtension, config.GenerateStaticDeserializeWithCtor) 
+                + AddB(config.GenerateStaticDeserializeIntoInstance, config.GenerateDeserializeOnInstance)
+                + AddB(config.GenerateStaticSerialize, true);
+
+            return config;
+        }
+
+        private static int AddB(bool a, bool b) => (a?1:0) + (b?1:0);
+
+    }
+
+}

--- a/NonSucking.Framework.Serialization/NoosonGeneratorContext.cs
+++ b/NonSucking.Framework.Serialization/NoosonGeneratorContext.cs
@@ -11,7 +11,7 @@ namespace NonSucking.Framework.Serialization
     5. Maybe future factory class for instance creation in deserialize (For now you can pass an instance into the method)
     6. Resolver Table for dynamic types, for runtime type serialization
      */
-    public record NoosonGeneratorContext(GlobalContext GlobalContext, SourceProductionContext GeneratorContext, GeneratedFile GeneratedFile, GeneratedType DefaultGeneratedType, string ReaderWriterName, ISymbol MainSymbol, bool UseAdvancedTypes, MethodType MethodType, string? WriterTypeName = null, string? ReaderTypeName = null)
+    public record NoosonGeneratorContext(GlobalContext GlobalContext, SourceProductionContext GeneratorContext, GeneratedFile GeneratedFile, GeneratedType DefaultGeneratedType, string ReaderWriterName, ISymbol MainSymbol, bool UseAdvancedTypes, MethodType MethodType, string MethodName, string? WriterTypeName = null, string? ReaderTypeName = null)
     {
         internal const string Category = "SerializationGenerator";
         internal const string IdPrefix = "NSG";

--- a/NonSucking.Framework.Serialization/Properties/launchSettings.json
+++ b/NonSucking.Framework.Serialization/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NonSucking.Framework.Serialization": {
       "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\DEMO\\DEMO.csproj"
+      "targetProject": "..\\..\\OctoAwesome\\octoawesome\\OctoAwesome\\OctoAwesome.Basics\\OctoAwesome.Basics.csproj"
     }
   }
 }

--- a/NonSucking.Framework.Serialization/Properties/launchSettings.json
+++ b/NonSucking.Framework.Serialization/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NonSucking.Framework.Serialization": {
       "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\..\\OctoAwesome\\octoawesome\\OctoAwesome\\OctoAwesome.Basics\\OctoAwesome.Basics.csproj"
+      "targetProject": "..\\DEMO\\DEMO.csproj"
     }
   }
 }

--- a/NonSucking.Framework.Serialization/Serializers/CtorSerializer.cs
+++ b/NonSucking.Framework.Serialization/Serializers/CtorSerializer.cs
@@ -48,7 +48,7 @@ namespace NonSucking.Framework.Serialization.Serializers
             {
                 List<IMethodSymbol> constructors = GetCtors(typeSymbol);
                 ctorArguments
-                    = GetStatementForCtorCall(constructors, localDeclarations, instanceName, out ctorArgumentNames);
+                    = GetStatementForCtorCall(constructors, localDeclarations, out ctorArgumentNames);
             }
 
 
@@ -92,7 +92,7 @@ namespace NonSucking.Framework.Serialization.Serializers
 
         private static List<string> GetLocalDeclarations(List<string> localVariableNames, string instanceName)
         {
-            var indexOf = instanceName.IndexOf(Helper.localVariableSuffix);
+            var indexOf = instanceName.IndexOf(Consts.LocalVariableSuffix);
             if (indexOf < 0)
                 return localVariableNames;
             var shouldContain = instanceName.Substring(0, indexOf);
@@ -101,11 +101,11 @@ namespace NonSucking.Framework.Serialization.Serializers
                 = localVariableNames
                 .Where(text =>
                 {
-                    int firstIndex = text.IndexOf(Helper.localVariableSuffix);
+                    int firstIndex = text.IndexOf(Consts.LocalVariableSuffix);
                     if (firstIndex == -1)
                         return false;
-                    firstIndex += +Helper.localVariableSuffix.Length;
-                    int secondIndex = text.IndexOf(Helper.localVariableSuffix, firstIndex);
+                    firstIndex += Consts.LocalVariableSuffix.Length;
+                    int secondIndex = text.IndexOf(Consts.LocalVariableSuffix, firstIndex);
                     if (secondIndex == -1)
                         return false;
                     if (text.Substring(firstIndex, secondIndex - firstIndex) != shouldContain)
@@ -127,7 +127,7 @@ namespace NonSucking.Framework.Serialization.Serializers
             {
                 var declaration
                     = localDeclarations
-                    .FirstOrDefault(declaration => Helper.MatchIdentifierWithPropName(declaration, property.symbol.Name));
+                    .FirstOrDefault(declaration => Helper.MatchIdentifierWithPropName(property.symbol.Name, declaration));
 
                 if (declaration is null)
                 {
@@ -156,7 +156,7 @@ namespace NonSucking.Framework.Serialization.Serializers
             {
                 var declaration
                     = localDeclarations
-                    .FirstOrDefault(declaration => Helper.MatchIdentifierWithPropName(declaration, property.symbol.Name));
+                    .FirstOrDefault(declaration => Helper.MatchIdentifierWithPropName(property.symbol.Name, declaration));
 
                 if (declaration is null)
                 {
@@ -217,7 +217,7 @@ namespace NonSucking.Framework.Serialization.Serializers
             return properties;
         }
 
-        internal static ArgumentListSyntax GetStatementForCtorCall(List<IMethodSymbol> constructors, List<string> localDeclarations, string instanceName, out List<string> ctorArguments)
+        internal static ArgumentListSyntax GetStatementForCtorCall(List<IMethodSymbol> constructors, List<string> localDeclarations, out List<string> ctorArguments)
         {
             ctorArguments = new List<string>();
             if (constructors.Count == 0)
@@ -240,7 +240,7 @@ namespace NonSucking.Framework.Serialization.Serializers
 
                     var matchedDeclaration
                         = localDeclarations
-                        .FirstOrDefault(identifier => Helper.MatchIdentifierWithPropName(identifier, parameterName));
+                        .FirstOrDefault(identifier => Helper.MatchIdentifierWithPropName(parameterName, identifier));
 
                     if (string.IsNullOrWhiteSpace(matchedDeclaration))
                     {

--- a/NonSucking.Framework.Serialization/Templates/AdditionalSource/BinaryRWExtensions.cs
+++ b/NonSucking.Framework.Serialization/Templates/AdditionalSource/BinaryRWExtensions.cs
@@ -8,7 +8,7 @@ namespace NonSucking.Framework.Serialization
     /// <summary>
     /// Extension methods for <see cref="BinaryReader"/> and <see cref="BinaryWriter"/>.
     /// </summary>
-    public static class BinaryRWExtensions
+    internal static class BinaryRWExtensions
     {
         /// <summary>
         /// Read exact number of bytes from <see cref="BinaryReader"/>.

--- a/NonSucking.Framework.Serialization/Templates/Attribute/NoosonConfigurationAttribute.cs
+++ b/NonSucking.Framework.Serialization/Templates/Attribute/NoosonConfigurationAttribute.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+using System;
+
+namespace NonSucking.Framework.Serialization
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    internal class NoosonConfigurationAttribute : System.Attribute
+    {
+
+        public bool GenerateDeserializeExtension { get; set; } = true;
+        //public bool EnableNullability { get; set; } = true; Not supported yet, as this requires alot of work to undo 
+        public bool DisableWarnings { get; set; } = false;
+
+        public bool GenerateStaticDeserializeWithCtor { get; set; } = true;
+        public string NameOfStaticDeserializeWithCtor { get; set; } = "Deserialize";
+
+        public string NameOfStaticDeserializeWithOutParams { get; set; } = "Deserialize";
+
+        /// <summary>
+        /// Will be automatically enabled when <see cref="GenerateDeserializeOnInstance"/> or <see cref="GenerateDeserializeExtension"/> is enabled
+        /// </summary>
+        public bool GenerateStaticDeserializeIntoInstance { get; set; } = true; //Currently required for GenerateDeserializeOnInstance 
+        public string NameOfStaticDeserializeIntoInstance { get; set; } = "Deserialize";
+
+        public bool GenerateDeserializeOnInstance { get; set; } = true;
+        public string NameOfDeserializeOnInstance { get; set; } = "DeserializeSelf";
+
+        public bool GenerateStaticSerialize { get; set; } = true;
+        public string NameOfStaticSerialize { get; set; } = "Serialize";
+        public string NameOfSerialize { get; set; } = "Serialize";
+
+    }
+}
+
+

--- a/NonSucking.Framework.Serialization/Templates/NoosonConfigurationAttributeTemplate.cs
+++ b/NonSucking.Framework.Serialization/Templates/NoosonConfigurationAttributeTemplate.cs
@@ -1,0 +1,11 @@
+﻿using NonSucking.Framework.Serialization.Templates;
+
+namespace NonSucking.Framework.Serialization.Attributes
+{
+    public class NoosonConfigurationAttributeTemplate : Template
+    {
+        public override string Namespace { get; } = "NonSucking.Framework.Serialization";
+        public override string Name { get; } = "NoosonConfigurationAttribute";
+        public override TemplateKind Kind { get; } = TemplateKind.Attribute;
+    }
+}


### PR DESCRIPTION
* added new config attribute, so one can control more things about nooson, like the method names, if certain methods should be generated and more
* respect the nooson config attribute on references assemblies, so that base methods and more are called correctly
* fixed method call serializer not calling serialize and deserialize correctly, because the methods may have different names and maybe don't exist at all
* fixed method call serializer not calling the out params deserialize of the base class, if it has a matching method to call, because without this the deserializtion wouldn't be in line with the serialize
* added a new helper to quickly check if two symbols are from the same assembly
* added a new helper to check for equality of two symbols, by wrapping the SymbolEqualityComparer
* added a new extension method for enumerables, where one can compare the content of two lists based on a compare method, which is especially helpfull when comparing method parameters
* fixed missing new, virtual and override modifiers of methods, because the base wasn't found correctly or the base was generated method or even in another assembly
* fixed deserialize method with out params having the wrong accessibility, because if one parameter is internal, the whole method has to be internal, as it would otherwise result in inconsistent accessibility declarations