### PR TITLE
Always generate reader writer bw extensions

### DIFF
--- a/NonSucking.Framework.Serialization/NoosonGenerator.cs
+++ b/NonSucking.Framework.Serialization/NoosonGenerator.cs
@@ -237,8 +237,9 @@ namespace NonSucking.Framework.Serialization
                    gc.Config.GeneratedNamespace + ".IBinaryReader") is not null;
             foreach (Template template in templates)
             {
-                if (template.Kind == TemplateKind.AdditionalSource &&
-                    source.Compilation.GetTypeByMetadataName(template.FullName) is null)
+                if (template.Kind == TemplateKind.AdditionalSource)
+                    //&& source.Compilation.GetTypeByMetadataName(template.FullName) is ITypeSymbol ts TODO: Needs work, detecting existing public, same namespace and more
+
                     sourceProductionContext.AddSource(template.Name, template.ToString());
             }
 


### PR DESCRIPTION
* because currently when referencing nooson framework extension and serialization the extensions are not generated but also internal, so we get compiler errors in the target project