### PR TITLE
Add remove method on type container

### DIFF
--- a/NonSucking.Framework.Extension/IoC/DomainTypeContainer.cs
+++ b/NonSucking.Framework.Extension/IoC/DomainTypeContainer.cs
@@ -82,5 +82,11 @@ namespace NonSucking.Framework.Extension.IoC
 
         internal override void BuildCtorInformation(CtorInformation info)
             => internalTypeContainer.BuildCtorInformation(info);
+
+        public override void Remove<T>() 
+            => internalTypeContainer.Remove<T>();
+
+        public override void Remove(Type type) 
+            => internalTypeContainer.Remove(type);
     }
 }

--- a/NonSucking.Framework.Extension/IoC/ITypeContainer.cs
+++ b/NonSucking.Framework.Extension/IoC/ITypeContainer.cs
@@ -25,5 +25,16 @@ namespace NonSucking.Framework.Extension.IoC
 
         object GetOrNull(Type type);
         T GetOrNull<T>() where T : class;
+
+        /// <summary>
+        /// Removes the type from the type container, so it my not be resolved anymore
+        /// </summary>
+        /// <typeparam name="T">The type to remove</typeparam>
+        void Remove<T>() where T : class;
+        /// <summary>
+        /// Removes the type from the type container, so it my not be resolved anymore
+        /// </summary>
+        /// <param name="type">The type to remove</param>
+        void Remove(Type type);
     }
 }

--- a/NonSucking.Framework.Extension/IoC/StandaloneTypeContainer.cs
+++ b/NonSucking.Framework.Extension/IoC/StandaloneTypeContainer.cs
@@ -141,5 +141,12 @@ namespace NonSucking.Framework.Extension.IoC
 
         internal override void BuildCtorInformation(CtorInformation info)
             => BuildCtorInformation(typeRegister, typeInformationRegister, info);
+
+        public override void Remove<T>()
+            => Remove(typeof(T));
+        
+
+        public override void Remove(Type type)
+            => typeInformationRegister.Remove(type);
     }
 }

--- a/NonSucking.Framework.Extension/IoC/TypeContainerBase.cs
+++ b/NonSucking.Framework.Extension/IoC/TypeContainerBase.cs
@@ -23,6 +23,8 @@ namespace NonSucking.Framework.Extension.IoC
         public abstract void Register<TRegistrar, T>(object singelton) where T : class;
         public abstract bool TryResolve(Type type, out object instance);
         public abstract bool TryResolve<T>(out T instance) where T : class;
+        public abstract void Remove<T>() where T : class;
+        public abstract void Remove(Type type);
 
         public virtual object CreateObject(Type type)
         {
@@ -105,5 +107,6 @@ namespace NonSucking.Framework.Extension.IoC
                 yield return info;
             }
         }
+
     }
 }


### PR DESCRIPTION
* so that types can be unregistered if required, should be currently only used for cirumventing the dispose call, because the instance will still be held in the ctor information