### PR TITLE
Fix singletons created during dispose

### DIFF
--- a/NonSucking.Framework.Extension/IoC/StandaloneTypeContainer.cs
+++ b/NonSucking.Framework.Extension/IoC/StandaloneTypeContainer.cs
@@ -128,11 +128,12 @@ namespace NonSucking.Framework.Extension.IoC
         public override void Dispose()
         {
             typeRegister.Clear();
-            typeInformationRegister.Values
-                .Where(t => t.Behaviour == InstanceBehaviour.Singleton && t.Instance != this)
-                .Select(t => t.Instance as IDisposable)
-                .ToList()
-                .ForEach(i => i?.Dispose());
+
+            typeInformationRegister.Remove(typeof(StandaloneTypeContainer));
+            typeInformationRegister.Remove(typeof(ITypeContainer));
+
+            foreach (var item in typeInformationRegister.Values)
+                item.TryDispose();
 
             typeInformationRegister.Clear();
             typeInformationSemaphore.Dispose();
@@ -144,7 +145,7 @@ namespace NonSucking.Framework.Extension.IoC
 
         public override void Remove<T>()
             => Remove(typeof(T));
-        
+
 
         public override void Remove(Type type)
             => typeInformationRegister.Remove(type);

--- a/NonSucking.Framework.Extension/IoC/TypeInformation.cs
+++ b/NonSucking.Framework.Extension/IoC/TypeInformation.cs
@@ -57,6 +57,19 @@ namespace NonSucking.Framework.Extension.IoC
 
             Completed = !ctors.Any(c => !c.IsComplete);
         }
+
+        /// <summary>
+        /// Disposed the singleton instance, if existing and required
+        /// </summary>
+        public void TryDispose()
+        {
+            if (Behaviour != InstanceBehaviour.Singleton
+                || singeltonInstance is not null)
+                return;
+            if (singeltonInstance is IDisposable disposable)
+                disposable.Dispose();
+
+        }
     }
 
 }


### PR DESCRIPTION
* because we accessed the instance to check if it is disposable and created the instance during this, so now we have a method on the TypeInformation that can access the singletonInstance directly without lazy creating it