### PR TITLE
Use dotnet nuget push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,21 +89,7 @@ jobs:
           name: test-result
           path: '**/*.nupkg'
 
-      # Setup Nuget
-      - name: Setup NuGet.exe
+      - name: Deploy Nuget Package
+        run: dotnet nuget push "**/*.nupkg" -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json
+        shell: bash
         if: env.publish == 'true'
-        # You may pin to the exact commit or the version.
-        # uses: NuGet/setup-nuget@04b0c2b8d1b97922f67eca497d7cf0bf17b8ffe1
-        uses: NuGet/setup-nuget@v3
-        with:
-          # NuGet version to install. Can be `latest`, `preview`, a concrete version like `5.3.1`, or a semver range specifier like `5.x`.
-          # nuget-version: # optional, default is latest
-          # NuGet API Key to configure.
-          nuget-api-key: ${{secrets.NUGET_API_KEY}}
-          # Source to scope the NuGet API Key to.
-          # nuget-api-key-source: # optional
-
-      # Push nuget packages
-      - name: Publish packages
-        if: env.publish == 'true'
-        run: nuget push "**/*.nupkg" -src https://api.nuget.org/v3/index.json


### PR DESCRIPTION
* instead of relying on a third party action, we can just use the dotnet nuget push, since we have dotnet anyway